### PR TITLE
elf: fixup NewModuleFromReader

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -354,18 +354,14 @@ func (b *Module) Load() error {
 		if err != nil {
 			return err
 		}
-
-		b.file, err = elf.NewFile(fileReader)
-		if err != nil {
-			return err
-		}
 		defer fileReader.Close()
-	} else {
-		var err error
-		b.file, err = elf.NewFile(b.fileReader)
-		if err != nil {
-			return err
-		}
+		b.fileReader = fileReader
+	}
+
+	var err error
+	b.file, err = elf.NewFile(b.fileReader)
+	if err != nil {
+		return err
 	}
 
 	license, err := elfReadLicense(b.file)

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -2,12 +2,19 @@
 
 package elf
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
 type Module struct{}
 type Kprobe struct{}
 
 func NewModule(fileName string) *Module {
+	return nil
+}
+
+func NewModuleFromReader(fileReader io.ReaderAt) *Module {
 	return nil
 }
 


### PR DESCRIPTION
add missing function in _unsupported.go.

-----

@schu @iaguis PTAL

Notes: I tested with:
- https://github.com/weaveworks/tcptracer-bpf/pull/4
- https://github.com/kinvolk/scope/commits/alban/conn-perf-ebpf-guess-ci-assets