### PR TITLE
Example: use TableId instead of fixed id

### DIFF
--- a/examples/perf.go
+++ b/examples/perf.go
@@ -108,9 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// 0 refers to the first BPF_PERF_OUTPUT table
-	// (here chown_events) defined in our module.
-	table := bpf.NewTable(0, m)
+	table := bpf.NewTable(m.TableId("chown_events"), m)
 
 	channel := make(chan []byte)
 


### PR DESCRIPTION
I think that using the TableId function instead of a fixed number makes the example a little bit more clear for the users.