### PR TITLE
fail to detach kprobe on Module Close

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -114,9 +114,11 @@ func (bpf *Module) Close() {
 	C.bpf_module_destroy(bpf.p)
 	for k, v := range bpf.kprobes {
 		C.perf_reader_free(v)
-		desc := fmt.Sprintf("-:kprobes/%s", k)
-		descCS := C.CString(desc)
-		C.bpf_detach_kprobe(descCS)
+		descCS := C.CString(k)
+		ret, err := C.bpf_detach_kprobe(descCS)
+		if ret != 0 {
+			fmt.Errorf("fail to detach kprobe, %s", err)
+		}
 		C.free(unsafe.Pointer(descCS))
 	}
 	for _, fd := range bpf.funcs {


### PR DESCRIPTION
Please check latest BCC code:

static int bpf_detach_probe(const char *ev_name, const char *event_type)
{
  int kfd;
  char buf[256];
  snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/%s_events", event_type);
  kfd = open(buf, O_WRONLY | O_APPEND, 0);
  if (kfd < 0) {
    fprintf(stderr, "open(%s): %s\n", buf, strerror(errno));
    return -1;
  }

  **snprintf(buf, sizeof(buf), "-:%ss/%s_bcc_%d", event_type, ev_name, getpid()); < ---- The cmd is build here.**
  if (write(kfd, buf, strlen(buf)) < 0) {
    fprintf(stderr, "write(%s): %s\n", buf, strerror(errno));
    close(kfd);
    return -1;
  }
  close(kfd);

  return 0;
}
