### PR TITLE
bcc: cast reader explicitly

### DIFF
--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -128,7 +128,7 @@ func InitPerfMap(table *Table, receiverChan chan []byte) (*PerfMap, error) {
 			return nil, fmt.Errorf("failed to open perf buffer: %v", err)
 		}
 
-		perfFd := C.perf_reader_fd(reader)
+		perfFd := C.perf_reader_fd((*C.struct_perf_reader)(reader))
 
 		readers = append(readers, (*C.struct_perf_reader)(reader))
 


### PR DESCRIPTION
Newer versions of go (1.8+) are more strict about this, so the
compilation failed:

```
github.com/iovisor/gobpf/bcc
# github.com/iovisor/gobpf/bcc
bcc/perf.go:131: cannot use reader (type unsafe.Pointer) as type *C.struct_perf_reader in argument to func literal
```

Cast it explicitly.