### PR TITLE
Add support for uprobes

### DIFF
--- a/bcc/symbol.go
+++ b/bcc/symbol.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Louis McCormack
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcc
+
+import (
+	"fmt"
+	"regexp"
+	"sync"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I/usr/include/bcc/compat
+#cgo LDFLAGS: -lbcc
+#include <bcc/bpf_common.h>
+#include <bcc/libbpf.h>
+#include <bcc/bcc_syms.h>
+extern void foreach_symbol_callback(char*, uint64_t);
+*/
+import "C"
+
+type symbolAddress struct {
+	name string
+	addr uint64
+}
+
+//symbolCache will cache module lookups
+var symbolCache = struct {
+	cache         map[string][]*symbolAddress
+	currentModule string
+	lock          *sync.Mutex
+}{
+	cache:         map[string][]*symbolAddress{},
+	currentModule: "",
+	lock:          &sync.Mutex{},
+}
+
+type bccSymbol struct {
+	name         *C.char
+	demangleName *C.char
+	module       *C.char
+	offset       C.ulonglong
+}
+
+// resolveSymbolPath returns the file and offset to locate symname in module
+func resolveSymbolPath(module string, symname string, addr uint64, pid int) (string, uint64, error) {
+	symbol := &bccSymbol{}
+	symbolC := (*C.struct_bcc_symbol)(unsafe.Pointer(symbol))
+	moduleCS := C.CString(module)
+	defer C.free(unsafe.Pointer(moduleCS))
+	symnameCS := C.CString(symname)
+	defer C.free(unsafe.Pointer(symnameCS))
+
+	if pid == -1 {
+		pid = 0
+	}
+
+	res, err := C.bcc_resolve_symname(moduleCS, symnameCS, (C.uint64_t)(addr), C.int(pid), symbolC)
+	if res == 0 {
+		return C.GoString(symbolC.module), (uint64)(symbolC.offset), nil
+	}
+
+	return "", 0, fmt.Errorf("unable to locate symbol %s in module %s: %v", symname, module, err)
+}
+
+// getUserSymbolsAndAddresses finds a list of symbols associated with a module,
+// along with their addresses. The results are cached in the symbolCache and
+// returned
+func getUserSymbolsAndAddresses(module string) ([]*symbolAddress, error) {
+	symbolCache.lock.Lock()
+	defer symbolCache.lock.Unlock()
+	// return previously cached list if it exists
+	if _, ok := symbolCache.cache[module]; ok {
+		return symbolCache.cache[module], nil
+	}
+
+	symbolCache.cache[module] = []*symbolAddress{}
+	symbolCache.currentModule = module
+
+	moduleCS := C.CString(module)
+	defer C.free(unsafe.Pointer(moduleCS))
+	res := C.bcc_foreach_symbol(moduleCS, (C.SYM_CB)(unsafe.Pointer(C.foreach_symbol_callback)))
+	if res < 0 {
+		return nil, fmt.Errorf("unable to list symbols for %s", module)
+	}
+	return symbolCache.cache[module], nil
+}
+
+func matchUserSymbols(module, match string) ([]*symbolAddress, error) {
+	r, err := regexp.Compile(match)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex %s : %s", match, err)
+	}
+	matchedSymbols := []*symbolAddress{}
+	symbols, err := getUserSymbolsAndAddresses(module)
+	if err != nil {
+		return nil, err
+	}
+	for _, sym := range symbols {
+		if r.MatchString(sym.name) {
+			matchedSymbols = append(matchedSymbols, sym)
+		}
+	}
+	return matchedSymbols, nil
+}
+
+// foreach_symbol_callback is a gateway function that will be exported to C
+// so that it can be referenced as a function pointer
+//export foreach_symbol_callback
+func foreach_symbol_callback(symname *C.char, addr C.uint64_t) {
+	symbolCache.cache[symbolCache.currentModule] =
+		append(symbolCache.cache[symbolCache.currentModule], &symbolAddress{C.GoString(symname), (uint64)(addr)})
+}

--- a/examples/bcc/bash_readline/bash_readline.go
+++ b/examples/bcc/bash_readline/bash_readline.go
@@ -1,0 +1,107 @@
+// Copyright 2017 Louis McCormack
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/signal"
+
+	bpf "github.com/iovisor/gobpf/bcc"
+)
+
+import "C"
+
+const source string = `
+#include <uapi/linux/ptrace.h>
+
+struct readline_event_t {
+        u64 pid;
+        char str[80];
+};
+
+BPF_PERF_OUTPUT(readline_events);
+
+int get_return_value(struct pt_regs *ctx) {
+        struct readline_event_t event = {};
+        u32 pid;
+        if (!PT_REGS_RC(ctx))
+                return 0;
+        pid = bpf_get_current_pid_tgid();
+        event.pid = pid;
+        bpf_probe_read(&event.str, sizeof(event.str), (void *)PT_REGS_RC(ctx));
+        readline_events.perf_submit(ctx, &event, sizeof(event));
+
+        return 0;
+}
+`
+
+type readlineEvent struct {
+	Pid uint32
+	Str [80]byte
+}
+
+func main() {
+	m := bpf.NewModule(source, []string{})
+	defer m.Close()
+
+	readlineUretprobe, err := m.LoadUprobe("get_return_value")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load get_return_value: %s\n", err)
+		os.Exit(1)
+	}
+
+	err = m.AttachUretprobe("/bin/bash", "readline", readlineUretprobe, -1)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to attach return_value: %s\n", err)
+		os.Exit(1)
+	}
+
+	table := bpf.NewTable(m.TableId("readline_events"), m)
+
+	channel := make(chan []byte)
+
+	perfMap, err := bpf.InitPerfMap(table, channel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to init perf map: %s\n", err)
+		os.Exit(1)
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, os.Kill)
+
+	fmt.Printf("%10s\t%s\n", "PID", "COMMAND")
+	go func() {
+		var event readlineEvent
+		for {
+			data := <-channel
+			err := binary.Read(bytes.NewBuffer(data), binary.LittleEndian, &event)
+			if err != nil {
+				fmt.Printf("failed to decode received data: %s\n", err)
+				continue
+			}
+			// the return value comes padded with 4 null chars (ascii 0), so take the index of
+			// the fifth 0 as the end of input (C strings are null terminated)
+			comm := event.Str[:bytes.IndexByte(event.Str[4:], 0)+4]
+			fmt.Printf("%10d\t%s\n", event.Pid, comm)
+		}
+	}()
+
+	perfMap.Start()
+	<-sig
+	perfMap.Stop()
+}

--- a/examples/bcc/strlen_count/strlen_count.go
+++ b/examples/bcc/strlen_count/strlen_count.go
@@ -1,0 +1,109 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+
+	bpf "github.com/iovisor/gobpf/bcc"
+)
+
+import "C"
+
+const source string = `
+#include <uapi/linux/ptrace.h>
+typedef char strlenkey_t[80];
+BPF_HASH(counts, strlenkey_t);
+
+int count(struct pt_regs *ctx) {
+	if (!PT_REGS_PARM1(ctx))
+		return 0;
+
+	strlenkey_t key;
+	u64 zero = 0, *val;
+
+	bpf_probe_read(&key, sizeof(key), (void *)PT_REGS_PARM1(ctx));
+	val = counts.lookup_or_init(&key, &zero);
+	(*val)++;
+	return 0;
+}
+`
+
+var ansiEscape = regexp.MustCompile(`[[:cntrl:]]`)
+
+func decodeHexString(raw string) ([]byte, error) {
+	ret := ""
+	// split on whitespace, replace 0x66 --> 66, concatenate the results then hex decode
+	for _, c := range strings.Split(strings.Replace(raw, "0x", "", -1), " ") {
+		if c == "[" || c == "]" {
+			continue
+		}
+		if c == "0" {
+			break
+		}
+		ret = fmt.Sprintf("%s%s", ret, c)
+	}
+	return hex.DecodeString(ret)
+}
+
+func decodeHexInt(raw string) (uint64, error) {
+	return strconv.ParseUint(raw, 0, 64)
+}
+
+func main() {
+	pid := flag.Int("pid", -1, "attach to pid, default is all processes")
+	flag.Parse()
+	m := bpf.NewModule(source, []string{})
+	defer m.Close()
+
+	strlenUprobe, err := m.LoadUprobe("count")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load uprobe count: %s\n", err)
+		os.Exit(1)
+	}
+
+	err = m.AttachUprobe("c", "strlen", strlenUprobe, *pid)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to attach uprobe to strlen: %s\n", err)
+		os.Exit(1)
+	}
+
+	table := bpf.NewTable(m.TableId("counts"), m)
+
+	fmt.Println("Tracing strlen()... hit Ctrl-C to end.")
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	<-sig
+
+	fmt.Printf("%10s %s\n", "COUNT", "STRING")
+	for evt := range table.Iter() {
+		k, err := decodeHexString(evt.Key)
+		if err != nil {
+			continue
+		}
+
+		v, err := decodeHexInt(evt.Value)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to decode result: %s\n", err)
+		}
+		fmt.Printf("%10d \"%s\"\n", v, ansiEscape.ReplaceAll(k, []byte{}))
+	}
+}


### PR DESCRIPTION
Hi,

This PR adds supports for tracing uprobes.

It includes some new functions used to query the symbol cache for the location (file and offset) of function within userland code; and to retrieve a list of matching symbols (functions) from a given module (library or binary) to allow attaching to all symbols that match a certain pattern. (Both these ideas borrowed heavily from the Python implementation).

It also adds functions to the Module type to allow adding of uprobes, uretprobes, and all those that match a pattern.

Finally an example, strlen_count.go, of how to use these new functions.

I do have a query/problem that I could do with some advice on, regarding the example:

I have used a Table without a PerfMap (in contrast to the other example which is given). The tracing happens until the user hits Ctrl-C,and then we iterate over the table entries with the Table.Iter() function.

The problem I have is that results are returned as an Event{Key: string, Value: string} where Key and Value appear to be string representations of C *char strings, like:

"[ 0x66 0x76 0x33 0x0 ]" - i.e. this is a string, _not_ a series of chars. The only (ugly) way I could figure out to extract the actual string was to remove the 0x, concatenate each value and then use hex.DecodeString.

Is there a better way?

Many Thanks
Louis








