### PR TITLE
kretprobes: set maxactive

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -145,7 +145,7 @@ func (b *Module) EnableKprobe(secName string, maxactive int) error {
 	}
 	defer f.Close()
 
-	cmd := fmt.Sprintf("%s%d:%s %s\n", probeType, maxactiveStr, eventName, funcName)
+	cmd := fmt.Sprintf("%s%s:%s %s\n", probeType, maxactiveStr, eventName, funcName)
 	_, err = f.WriteString(cmd)
 	if err != nil {
 		// fallback without maxactive for kretprobes

--- a/elf/module.go
+++ b/elf/module.go
@@ -151,6 +151,12 @@ func writeKprobeEvent(probeType, eventName, funcName, maxactiveStr string) (int,
 	return kprobeId, nil
 }
 
+// EnableKprobe enables a kprobe/kretprobe identified by secName.
+// For kretprobes, you can configure the maximum number of instances
+// of the function that can be probed simultaneously with maxactive.
+// If maxactive is 0 it will be set to the default value: if CONFIG_PREEMPT is
+// enabled, this is max(10, 2*NR_CPUS); otherwise, it is NR_CPUS.
+// For kprobes, maxactive is ignored.
 func (b *Module) EnableKprobe(secName string, maxactive int) error {
 	var probeType, funcName string
 	isKretprobe := strings.HasPrefix(secName, "kretprobe/")
@@ -199,6 +205,8 @@ func (b *Module) EnableKprobe(secName string, maxactive int) error {
 	return nil
 }
 
+// IterKprobes returns a channel that emits the kprobes that included in the
+// module.
 func (b *Module) IterKprobes() <-chan *Kprobe {
 	ch := make(chan *Kprobe)
 	go func() {
@@ -210,6 +218,8 @@ func (b *Module) IterKprobes() <-chan *Kprobe {
 	return ch
 }
 
+// EnableKprobes enables all kprobes/kretprobes included in the module. The
+// value in maxactive will be applied to all the kretprobes.
 func (b *Module) EnableKprobes(maxactive int) error {
 	var err error
 	for _, kprobe := range b.probes {

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -18,7 +18,7 @@ func NewModuleFromReader(fileReader io.ReaderAt) *Module {
 	return nil
 }
 
-func (b *Module) EnableKprobe(secName string) error {
+func (b *Module) EnableKprobe(secName string, maxactive int) error {
 	return fmt.Errorf("not supported")
 }
 
@@ -26,7 +26,7 @@ func (b *Module) IterKprobes() <-chan *Kprobe {
 	return nil
 }
 
-func (b *Module) EnableKprobes() error {
+func (b *Module) EnableKprobes(maxactive int) error {
 	return fmt.Errorf("not supported")
 }
 


### PR DESCRIPTION
We are discussing adding a way to specify the maxactive field of a
kretprobe in the kernel:
https://github.com/iovisor/bcc/issues/1072#issuecomment-289777787

How do we expose this in gobpf? I see two possible ways:
- at build-time: `SEC("kretprobe?maxactive=128/inet_csk_accept")`
- at run-time: `m.EnableKprobe("kretprobe/inet_csk_accept", 128)`

This patch implements it at run-time. This might not not ideal because `EnableKprobes` (plural) would use the same maxactive for all kretprobes.

/cc @iaguis @schu

TODO:
- [x] test it