### PR TITLE
perf maps: add configurable parameters

### DIFF
--- a/bpf_test.go
+++ b/bpf_test.go
@@ -47,7 +47,7 @@ func TestModuleLoadELF(t *testing.T) {
 	if b == nil {
 		t.Fatal("prog is nil")
 	}
-	err := b.Load()
+	err := b.Load(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/elf/elf_unsupported.go
+++ b/elf/elf_unsupported.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 )
 
-func (b *Module) Load() error {
-	return fmt.Errorf("not supported")
-}
-
 // not supported; dummy struct
 type BPFKProbePerf struct{}
+type SectionParams struct{}
+
+func (b *Module) Load(parameters map[string]SectionParams) error {
+	return fmt.Errorf("not supported")
+}
 
 func NewBpfPerfEvent(fileName string) *BPFKProbePerf {
 	// not supported


### PR DESCRIPTION
Callers of b.Load() can optionally specifies parameters for each ELF section. This patch adds the following two parameters:
- PerfRingBufferPageCount. Default: 8 pages
- SkipPerfMapInitialization: Default: false

Useful for https://github.com/weaveworks/tcptracer-bpf/pull/37