### PR TITLE
elf: add missing select default

### DIFF
--- a/elf/perf.go
+++ b/elf/perf.go
@@ -176,6 +176,7 @@ func (pm *PerfMap) PollStart() {
 				select {
 				case <-pm.pollStop:
 					return
+				default:
 				}
 
 				var harvestCount C.int


### PR DESCRIPTION
Otherwise we block and do nothing.

Fixup for c520ae517435b1a4e01915b2f31004b60ff68600