### PR TITLE
Fix compilation error in 32-bit architectures

### DIFF
--- a/bpffs/fs.go
+++ b/bpffs/fs.go
@@ -3,11 +3,20 @@ package bpffs
 import (
 	"fmt"
 	"syscall"
+	"unsafe"
 )
 
-const (
-	BPFFSPath = "/sys/fs/bpf"
-)
+const BPFFSPath = "/sys/fs/bpf"
+
+var FsMagicBPFFS int32
+
+func init() {
+	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
+	magic := uint32(0xCAFE4A11)
+	// 0xCAFE4A11 overflows an int32, which is what's expected by Statfs_t.Type in 32bit platforms.
+	// To avoid conditional compilation for all 32bit/64bit platforms, we use an unsafe cast
+	FsMagicBPFFS = *(*int32)(unsafe.Pointer(&magic))
+}
 
 // IsMounted checks if the BPF fs is mounted already
 func IsMounted() (bool, error) {
@@ -15,8 +24,7 @@ func IsMounted() (bool, error) {
 	if err := syscall.Statfs(BPFFSPath, &data); err != nil {
 		return false, fmt.Errorf("cannot statfs %q: %v", BPFFSPath, err)
 	}
-	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
-	return data.Type == 0xCAFE4A11, nil
+	return int32(data.Type) == FsMagicBPFFS, nil
 }
 
 // Mount mounts the BPF fs if not already mounted

--- a/bpffs/fs.go
+++ b/bpffs/fs.go
@@ -7,8 +7,6 @@ import (
 
 const (
 	BPFFSPath = "/sys/fs/bpf"
-	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
-	FsMagicBPFFS = int64(0xCAFE4A11)
 )
 
 // IsMounted checks if the BPF fs is mounted already
@@ -17,7 +15,8 @@ func IsMounted() (bool, error) {
 	if err := syscall.Statfs(BPFFSPath, &data); err != nil {
 		return false, fmt.Errorf("cannot statfs %q: %v", BPFFSPath, err)
 	}
-	return data.Type == FsMagicBPFFS, nil
+	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
+	return data.Type == 0xCAFE4A11, nil
 }
 
 // Mount mounts the BPF fs if not already mounted

--- a/bpffs/fs.go
+++ b/bpffs/fs.go
@@ -12,6 +12,7 @@ var FsMagicBPFFS int32
 
 func init() {
 	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
+	// https://github.com/torvalds/linux/blob/v4.8/include/uapi/linux/magic.h#L80
 	magic := uint32(0xCAFE4A11)
 	// 0xCAFE4A11 overflows an int32, which is what's expected by Statfs_t.Type in 32bit platforms.
 	// To avoid conditional compilation for all 32bit/64bit platforms, we use an unsafe cast

--- a/bpffs/fs.go
+++ b/bpffs/fs.go
@@ -8,7 +8,7 @@ import (
 const (
 	BPFFSPath = "/sys/fs/bpf"
 	// https://github.com/coreutils/coreutils/blob/v8.27/src/stat.c#L275
-	FsMagicBPFFS = 0xCAFE4A11
+	FsMagicBPFFS = int64(0xCAFE4A11)
 )
 
 // IsMounted checks if the BPF fs is mounted already


### PR DESCRIPTION
I get error `bpffs/fs.go:20: constant 3405662737 overflows int32` in ARM, see https://circleci.com/gh/weaveworks/scope/7239