### PR TITLE
elf: add socket filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ sections (`SEC("...")`). Currently supported are:
 * `cgroup/skb`
 * `cgroup/sock`
 * `maps/...`
+* `socket...`
 
 Map definitions must correspond to `bpf_map_def` from [elf.go](https://github.com/iovisor/gobpf/blob/master/elf/elf.go)
 Otherwise you will encounter an error like `only one map with size 280 bytes allowed per section (check bpf_map_def)`.


### PR DESCRIPTION
We follow kernel's convention of taking sections that start with
"socket".

Also, rework cgroup API for consistency.