### PR TITLE
elf: add missing cgroup and socket filter maps initialization

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -146,9 +146,11 @@ func NewModule(fileName string) *Module {
 
 func NewModuleFromReader(fileReader io.ReaderAt) *Module {
 	return &Module{
-		fileReader: fileReader,
-		probes:     make(map[string]*Kprobe),
-		log:        make([]byte, 65536),
+		fileReader:     fileReader,
+		probes:         make(map[string]*Kprobe),
+		cgroupPrograms: make(map[string]*CgroupProgram),
+		socketFilters:  make(map[string]*SocketFilter),
+		log:            make([]byte, 65536),
 	}
 }
 


### PR DESCRIPTION
We were doing it for `NewModule()` but not for `NewModuleFromReader()`.