### PR TITLE
elf: don't close event FD if Kprobe wasn't enabled

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -562,6 +562,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						Name:  secName,
 						insns: insns,
 						fd:    int(progFd),
+						efd:   -1,
 					}
 				case isCgroupSkb:
 					fallthrough
@@ -637,6 +638,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),
+					efd:   -1,
 				}
 			case isCgroupSkb:
 				fallthrough

--- a/elf/module.go
+++ b/elf/module.go
@@ -386,8 +386,11 @@ func disableKprobe(eventName string) error {
 func (b *Module) closeProbes() error {
 	var funcName string
 	for _, probe := range b.probes {
-		if err := syscall.Close(probe.efd); err != nil {
-			return fmt.Errorf("error closing perf event fd: %v", err)
+		if probe.efd != -1 {
+			if err := syscall.Close(probe.efd); err != nil {
+				return fmt.Errorf("error closing perf event fd: %v", err)
+			}
+			probe.efd = -1
 		}
 		if err := syscall.Close(probe.fd); err != nil {
 			return fmt.Errorf("error closing probe fd: %v", err)


### PR DESCRIPTION
Trying to close it was making `Module.Close()` fail for Kprobes that
weren't enabled.