### PR TITLE
bcc: fix build issues when using bcc 0.4

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -355,9 +355,9 @@ func (bpf *Module) TableIter() <-chan map[string]interface{} {
 	return ch
 }
 
-func (bpf *Module) attachXDP(devName string, fd int) error {
+func (bpf *Module) attachXDP(devName string, fd int, flags uint32) error {
 	devNameCS := C.CString(devName)
-	res, err := C.bpf_attach_xdp(devNameCS, C.int(fd))
+	res, err := C.bpf_attach_xdp(devNameCS, C.int(fd), C.uint32_t(flags))
 	defer C.free(unsafe.Pointer(devNameCS))
 
 	if res != 0 || err != nil {
@@ -368,10 +368,10 @@ func (bpf *Module) attachXDP(devName string, fd int) error {
 
 // AttachXDP attaches a xdp fd to a device.
 func (bpf *Module) AttachXDP(devName string, fd int) error {
-	return bpf.attachXDP(devName, fd)
+	return bpf.attachXDP(devName, fd, 0)
 }
 
 // RemoveXDP removes any xdp from this device.
 func (bpf *Module) RemoveXDP(devName string) error {
-	return bpf.attachXDP(devName, -1)
+	return bpf.attachXDP(devName, -1, 0)
 }

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -38,7 +38,7 @@ for kernel_version in "${kernel_versions[@]}"; do
     --dns=8.8.8.8 \
     --stage1-name="kinvolk.io/aci/rkt/stage1-kvm:${rkt_version},kernelversion=${kernel_version}" \
     --volume=gobpf,kind=host,source="$PWD" \
-    docker://schu/gobpf-ci \
+    docker://schu/gobpf-ci:3b65a12efe11503eac6ac2d6bfeff2b87f413088 \
     --memory=1024M \
     --mount=volume=gobpf,target=/go/src/github.com/iovisor/gobpf \
     --environment=GOPATH=/go \

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -54,4 +54,6 @@ for kernel_version in "${kernel_versions[@]}"; do
   if [[ $test_status -ne 0 ]]; then
     exit "$test_status"
   fi
+
+  sudo ./rkt/rkt gc --grace-period=0
 done


### PR DESCRIPTION
(Work-in-progress, please do not merge. After bcc 0.4 has been released, I will get back to this PR.)

Fix build problems in `bcc/symbol.go` and `bcc/perf.go` when using bcc 0.4.
    
* As `bcc_foreach_symbol()` was renamed to `bcc_foreach_function_symbol()` since https://github.com/iovisor/bcc/commit/fcb2ed8e5895, we should conditionally run different functions. bcc04: `bcc_foreach_function_symbol`, !bcc: `bcc_foreach_symbol`

* As prototype of `bcc_resolve_symname()` was changed to include `bcc_symbol_option` since https://github.com/iovisor/bcc/commit/aff6ce7075da, we should contidionally use different function prototypes. bcc04: with `bcc_symbol_option`, !bcc: without `bcc_symbol_option`.

* As prototype of `bcc_open_perf_buffer()` was changed to include `perf_reader_lost_cb` since https://github.com/iovisor/bcc/commit/4b764de6bcb3, we should contidionally use different function prototypes. bcc04: with `perf_reader_lost_cb`, !bcc: without `perf_reader_lost_cb`.
