### PR TITLE
Increase size of log buffer

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -149,7 +149,7 @@ func newModule() *Module {
 		cgroupPrograms:     make(map[string]*CgroupProgram),
 		socketFilters:      make(map[string]*SocketFilter),
 		tracepointPrograms: make(map[string]*TracepointProgram),
-		log:                make([]byte, 65536),
+		log:                make([]byte, 262144),
 	}
 }
 


### PR DESCRIPTION
The bpf() syscall has a log_buf parameter for the verifier to write
output. When the buffer is too small, bpf() fails, even if the program
is good otherwise.

Symptoms:
error while loading "kretprobe/foobar" (no space left on device)

Changing the size from 64K to 256K works for me in practice