### PR TITLE
elf: increase size of log buffer again

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -149,7 +149,7 @@ func newModule() *Module {
 		cgroupPrograms:     make(map[string]*CgroupProgram),
 		socketFilters:      make(map[string]*SocketFilter),
 		tracepointPrograms: make(map[string]*TracepointProgram),
-		log:                make([]byte, 262144),
+		log:                make([]byte, 524288),
 	}
 }
 


### PR DESCRIPTION
0e0349c already increased the log buffer but while testing on kernel
4.4 I ran out of buffer space again.

Let's try with 512k. Hopefully this is enough.