### PR TITLE
elf,bpf_test: Improve error checks

### DIFF
--- a/bpf_test.go
+++ b/bpf_test.go
@@ -17,7 +17,6 @@
 package bpf
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/iovisor/gobpf/bcc"
@@ -255,9 +254,7 @@ func TestModuleLoadELF(t *testing.T) {
 		t.Fatal("prog is nil")
 	}
 	if err := b.Load(nil); err != nil {
-		if !strings.Contains(err.Error(), "invalid argument") {
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
 	defer b.Close()
 

--- a/elf/elf.go
+++ b/elf/elf.go
@@ -288,9 +288,6 @@ func elfReadVersion(file *elf.File) (uint32, error) {
 			return 0, errors.New("version is not a __u32")
 		}
 		version := *(*C.uint32_t)(unsafe.Pointer(&data[0]))
-		if err != nil {
-			return 0, err
-		}
 		return uint32(version), nil
 	}
 	return 0, nil


### PR DESCRIPTION
Remove an unnecessary error check in `elfReadVersion()`. The error is already being checked above in the same function, https://github.com/iovisor/gobpf/blob/master/elf/elf.go#L284

We should check for a specific error code `os.ErrInvalid`, instead of comparing error strings with each other.
