### PR TITLE
Update to bcc 0.5.0

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -47,6 +47,8 @@ type compileRequest struct {
 	rspCh  chan *Module
 }
 
+const defaultLogLevel = 1
+
 const (
 	BPF_PROBE_ENTRY = iota
 	BPF_PROBE_RETURN
@@ -172,7 +174,7 @@ func (bpf *Module) load(name string, progType int) (int, error) {
 	}
 	logbuf := make([]byte, 65536)
 	logbufP := (*C.char)(unsafe.Pointer(&logbuf[0]))
-	fd, err := C.bpf_prog_load(uint32(progType), start, size, license, version, logbufP, C.uint(len(logbuf)))
+	fd, err := C.bpf_prog_load(uint32(progType), nameCS, start, size, license, version, defaultLogLevel, logbufP, C.uint(len(logbuf)))
 	if fd < 0 {
 		msg := string(logbuf[:bytes.IndexByte(logbuf, 0)])
 		if len(msg) > 0 {

--- a/semaphore.sh
+++ b/semaphore.sh
@@ -38,7 +38,7 @@ for kernel_version in "${kernel_versions[@]}"; do
     --dns=8.8.8.8 \
     --stage1-name="kinvolk.io/aci/rkt/stage1-kvm:${rkt_version},kernelversion=${kernel_version}" \
     --volume=gobpf,kind=host,source="$PWD" \
-    docker://schu/gobpf-ci:3b65a12efe11503eac6ac2d6bfeff2b87f413088 \
+    docker://schu/gobpf-ci:d54e7abfe980c7d59ca6929f4f3552ea891260b0 \
     --memory=1024M \
     --mount=volume=gobpf,target=/go/src/github.com/iovisor/gobpf \
     --environment=GOPATH=/go \


### PR DESCRIPTION
Note that `bpf_prog_load` as in bcc 0.5.0 prints the log buf to stderr in any case, even when successful, i.e. there's no way currently to suppress output as far as I have seen. In master this was already changed to only print when `ret < 0`: https://github.com/iovisor/bcc/commit/c669257c1f16eae4c695866bea147f57a9092b80 Ideally, we would be able to disable output entirely.

