### PR TITLE
Move to retrieving byte slices from BCC table entries instead of formatted strings

### DIFF
--- a/bcc/bccencoding/encoding.go
+++ b/bcc/bccencoding/encoding.go
@@ -1,0 +1,112 @@
+package bccencoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+var (
+	ByteOrder binary.ByteOrder
+)
+
+func init() {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		ByteOrder = binary.LittleEndian
+	} else {
+		ByteOrder = binary.BigEndian
+	}
+}
+
+func Unmarshal(data []byte, dest interface{}) error {
+	// TODO: This function relies on struct ordering being the same layout
+	// in memory as it is in the definition. While this is true today and
+	// quite unlikely to change stranger things have happened. Use at your
+	// own risk!
+	//
+	// In the future or if this somehow becomes a problem perhaps `bcc:"0"`
+	// type tags could be added to define field ordering definitively.
+	ptr := reflect.ValueOf(dest)
+	if ptr.Kind() != reflect.Ptr {
+		return fmt.Errorf("Wanted pointer to value but got type: %s", ptr.Kind())
+	}
+	elem := ptr.Elem()
+
+	var (
+		// create these here so they are not created all over
+		valu32 uint32
+		valu64 uint64
+	)
+
+	switch elem.Kind() {
+	case reflect.Uint32:
+		if len(data) != 4 {
+			return errors.New("Provided []byte not a uint32 type")
+		}
+		valu32 = ByteOrder.Uint32(data)
+		elem.SetUint(uint64(valu32))
+	case reflect.Uint64:
+		if len(data) != 8 {
+			return errors.New("Provided []byte not a uint64 type")
+		}
+		valu64 = ByteOrder.Uint64(data)
+		elem.SetUint(valu64)
+	case reflect.String:
+		nullIndex := bytes.IndexByte(data, 0)
+		if nullIndex == -1 {
+			// No terminator, so it's likely the string is
+			// truncated, so use full string
+			elem.SetString(string(data))
+		} else {
+			elem.SetString(string(data[:nullIndex]))
+		}
+	case reflect.Struct:
+		indr := reflect.Indirect(elem)
+
+		byteCursor := 0
+
+		for i := 0; i < indr.NumField(); i++ {
+			val := indr.Field(i)
+
+			// TODO: Add additional types if desired. For now these should
+			// cover most existing eBPF scripts.
+			switch val.Kind() {
+			case reflect.Uint32:
+				valu32 = ByteOrder.Uint32(data[byteCursor : byteCursor+4])
+				//TODO: this feels weird. is it ok?
+				val.SetUint(uint64(valu32))
+				// set in struct
+				byteCursor += 4
+			case reflect.Uint64:
+				valu64 = ByteOrder.Uint64(data[byteCursor : byteCursor+8])
+				val.SetUint(valu64)
+				byteCursor += 8
+			case reflect.String:
+				// advance the cursor until reaching a null-terminated
+				// string. store the start so we can use it for a slice
+				// index to convert to string at the end.
+				start := byteCursor
+				for ; data[byteCursor] != 0; byteCursor++ {
+				}
+
+				val.SetString(string(data[start:byteCursor]))
+
+				// just go past the null terminator and on to the next
+				// field
+				byteCursor++
+			default:
+				return fmt.Errorf("Don't know how to unmarshal type: %s", val.Kind())
+			}
+		}
+	default:
+		return fmt.Errorf("Don't know how to unmarshal type: %s", elem.Kind())
+	}
+	return nil
+}

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -15,9 +15,10 @@
 package bcc
 
 import (
-	"bytes"
 	"fmt"
 	"unsafe"
+
+	"github.com/iovisor/gobpf/bcc/bccencoding"
 )
 
 /*
@@ -64,49 +65,30 @@ func (table *Table) Config() map[string]interface{} {
 	}
 }
 
-func (table *Table) keyToBytes(keyStr string) ([]byte, error) {
-	mod := table.module.p
-	key_size := C.bpf_table_key_size_id(mod, table.id)
-	key := make([]byte, key_size)
-	keyP := unsafe.Pointer(&key[0])
-	keyCS := C.CString(keyStr)
-	defer C.free(unsafe.Pointer(keyCS))
-	r := C.bpf_table_key_sscanf(mod, table.id, keyCS, keyP)
-	if r != 0 {
-		return nil, fmt.Errorf("error scanning key (%v) from string", keyStr)
-	}
-	return key, nil
-}
-
-func (table *Table) leafToBytes(leafStr string) ([]byte, error) {
-	mod := table.module.p
-	leaf_size := C.bpf_table_leaf_size_id(mod, table.id)
-	leaf := make([]byte, leaf_size)
-	leafP := unsafe.Pointer(&leaf[0])
-	leafCS := C.CString(leafStr)
-	defer C.free(unsafe.Pointer(leafCS))
-	r := C.bpf_table_leaf_sscanf(mod, table.id, leafCS, leafP)
-	if r != 0 {
-		return nil, fmt.Errorf("error scanning leaf (%v) from string", leafStr)
-	}
-	return leaf, nil
-}
-
 // Entry represents a table entry.
 type Entry struct {
-	Key   string
-	Value string
+	Key   []byte
+	Value []byte
+}
+
+// TODO: could potentially store KeyFields and ValueFields in Table to avoid
+// reflecting to get the types on all calls after first.
+//
+// and - for max performance, reflection shouldn't be used at all. the code to
+// deserialize into the struct should be generated
+func (entry *Entry) UnmarshalValue(dest interface{}) error {
+	return bccencoding.Unmarshal(entry.Value, dest)
+}
+
+func (entry *Entry) UnmarshalKey(dest interface{}) error {
+	return bccencoding.Unmarshal(entry.Key, dest)
 }
 
 // Get takes a key and returns the value or nil, and an 'ok' style indicator.
-func (table *Table) Get(keyStr string) (interface{}, bool) {
+func (table *Table) Get(key []byte) (*Entry, bool) {
 	mod := table.module.p
 	fd := C.bpf_table_fd_id(mod, table.id)
 	leaf_size := C.bpf_table_leaf_size_id(mod, table.id)
-	key, err := table.keyToBytes(keyStr)
-	if err != nil {
-		return nil, false
-	}
 	leaf := make([]byte, leaf_size)
 	keyP := unsafe.Pointer(&key[0])
 	leafP := unsafe.Pointer(&leaf[0])
@@ -114,60 +96,42 @@ func (table *Table) Get(keyStr string) (interface{}, bool) {
 	if r != 0 {
 		return nil, false
 	}
-	leafStr := make([]byte, leaf_size*8)
-	leafStrP := (*C.char)(unsafe.Pointer(&leafStr[0]))
-	r = C.bpf_table_leaf_snprintf(mod, table.id, leafStrP, C.size_t(len(leafStr)), leafP)
-	if r != 0 {
-		return nil, false
-	}
-	return Entry{
-		Key:   keyStr,
-		Value: string(leafStr[:bytes.IndexByte(leafStr, 0)]),
+	return &Entry{
+		Key:   key,
+		Value: leaf,
 	}, true
 }
 
 // Set a key to a value.
-func (table *Table) Set(keyStr, leafStr string) error {
+func (table *Table) Set(key, leaf []byte) error {
 	if table == nil || table.module.p == nil {
 		panic("table is nil")
 	}
 	fd := C.bpf_table_fd_id(table.module.p, table.id)
-	key, err := table.keyToBytes(keyStr)
-	if err != nil {
-		return err
-	}
-	leaf, err := table.leafToBytes(leafStr)
-	if err != nil {
-		return err
-	}
 	keyP := unsafe.Pointer(&key[0])
 	leafP := unsafe.Pointer(&leaf[0])
 	r, err := C.bpf_update_elem(fd, keyP, leafP, 0)
 	if r != 0 {
-		return fmt.Errorf("Table.Set: unable to update element (%s=%s): %v", keyStr, leafStr, err)
+		return fmt.Errorf("Table.Set: unable to update element (%s=%s): %v", string(key), string(leaf), err)
 	}
 	return nil
 }
 
 // Delete a key.
-func (table *Table) Delete(keyStr string) error {
+func (table *Table) Delete(key []byte) error {
 	fd := C.bpf_table_fd_id(table.module.p, table.id)
-	key, err := table.keyToBytes(keyStr)
-	if err != nil {
-		return err
-	}
 	keyP := unsafe.Pointer(&key[0])
 	r, err := C.bpf_delete_elem(fd, keyP)
 	if r != 0 {
-		return fmt.Errorf("Table.Delete: unable to delete element (%s): %v", keyStr, err)
+		return fmt.Errorf("Table.Delete: unable to delete element (%s): %v", string(key), err)
 	}
 	return nil
 }
 
 // Iter returns a receiver channel to iterate over all table entries.
-func (table *Table) Iter() <-chan Entry {
+func (table *Table) Iter() <-chan *Entry {
 	mod := table.module.p
-	ch := make(chan Entry, 128)
+	ch := make(chan *Entry, 128)
 	go func() {
 		defer close(ch)
 		fd := C.bpf_table_fd_id(mod, table.id)
@@ -180,40 +144,40 @@ func (table *Table) Iter() <-chan Entry {
 		alternateKeys := []byte{0xff, 0x55}
 		res := C.bpf_lookup_elem(fd, keyP, leafP)
 		// make sure the start iterator is an invalid key
-		for i := 0; i <= len(alternateKeys); i++ {
+		for i := 0; i < len(alternateKeys); i++ {
 			if res < 0 {
 				break
 			}
 			for j := range key {
+				fmt.Println(len(key), len(alternateKeys))
 				key[j] = alternateKeys[i]
 			}
-			res = C.bpf_lookup_elem(fd, keyP, leafP)
 		}
 		if res == 0 {
 			return
 		}
-		keyStr := make([]byte, key_size*8)
-		leafStr := make([]byte, leaf_size*8)
-		keyStrP := (*C.char)(unsafe.Pointer(&keyStr[0]))
-		leafStrP := (*C.char)(unsafe.Pointer(&leafStr[0]))
 		for res = C.bpf_get_next_key(fd, keyP, keyP); res == 0; res = C.bpf_get_next_key(fd, keyP, keyP) {
 			r := C.bpf_lookup_elem(fd, keyP, leafP)
 			if r != 0 {
 				continue
 			}
-			r = C.bpf_table_key_snprintf(mod, table.id, keyStrP, C.size_t(len(keyStr)), keyP)
-			if r != 0 {
-				break
+			entry := &Entry{
+				Key:   make([]byte, key_size),
+				Value: make([]byte, leaf_size),
 			}
-			r = C.bpf_table_leaf_snprintf(mod, table.id, leafStrP, C.size_t(len(leafStr)), leafP)
-			if r != 0 {
-				break
-			}
-			ch <- Entry{
-				Key:   string(keyStr[:bytes.IndexByte(keyStr, 0)]),
-				Value: string(leafStr[:bytes.IndexByte(leafStr, 0)]),
-			}
+			copy(entry.Key, key)
+			copy(entry.Value, leaf)
+			ch <- entry
 		}
 	}()
 	return ch
+}
+
+func (table *Table) Clear() error {
+	for entry := range table.Iter() {
+		if err := table.Delete(entry.Key); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/examples/bcc/xdp/xdp_drop.go
+++ b/examples/bcc/xdp/xdp_drop.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 
 	bpf "github.com/iovisor/gobpf/bcc"
+	"github.com/iovisor/gobpf/bcc/bccencoding"
 )
 
 /*
@@ -158,18 +158,8 @@ func main() {
 
 	fmt.Printf("\n{IP protocol-number}: {total dropped pkts}\n")
 	for entry := range dropcnt.Iter() {
-		var key, value uint64
-		var err error
-
-		key, err = strconv.ParseUint(entry.Key, 0, 32)
-		if err != nil {
-			continue
-		}
-
-		value, err = strconv.ParseUint(entry.Value, 0, 64)
-		if err != nil {
-			continue
-		}
+		key := bccencoding.ByteOrder.Uint32(entry.Key)
+		value := bccencoding.ByteOrder.Uint64(entry.Value)
 
 		if value > 0 {
 			fmt.Printf("%v: %v pkts\n", key, value)


### PR DESCRIPTION
This PR updates `table.Entry` to contain a type of `[]byte` instead of `string`. This is due to confusion (e.g., https://github.com/iovisor/gobpf/issues/89) around the fact that these `string` were obtained from the `bpf_table_key_snprintf` function. `[]byte` does not require any hex decoding etc. like the `string`, just figuring out how to get the returned binary information into the proper Go type.

Also, things like `Clear` / `DeleteAll` (https://github.com/iovisor/gobpf/pull/91) become way more straightforward, because you have the verbatim bytes of the key in the first place, so it's easy to go back and delete a specific leaf.

It also adds methods `bccencoding.Unmarshal`, `entry.UnmarshalKey`, and `entry.UnmarshalValue` for fast iteration and prototyping of getting information from BCC. They do use reflection, but faster methods will always be available to users if desired because they can `binary.Read`, etc. Eventually code generators for this, such as an equivalent to https://github.com/pquerna/ffjson as compared to `encoding/json`, could be added as well if desired.

I do want to add another example and tests demonstrating struct unmarshalling, etc. `bccencoding.UnmarshalBytes` just covers `uint32`, `uint64`, `string`, and `struct` composed of those today.

cc @schu @iaguis  and also FYI @Pryz you might find this interesting 

**Notes:**

- [x] ~Is `bccencoding` a good package name with path of `github.com/iovisor/gobpf/bcc/encoding`? This doesn't seem to play nice with `goimports` so I might change the directory name.~
- [x] ~Maybe `bccencoding.UnmarshalBytes` should just be `Unmarshal`?~
- [ ] Unit tests still needed
- [ ] Adding more types (nested struct support, etc.)