### PR TITLE
AttachUretprobe prefix with r_, not p_

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -289,7 +289,7 @@ func (bpf *Module) AttachUretprobe(name, symbol string, fd, pid int) error {
 	if err != nil {
 		return err
 	}
-	evName := fmt.Sprintf("p_%s_0x%x", uprobeRegexp.ReplaceAllString(path, "_"), addr)
+	evName := fmt.Sprintf("r_%s_0x%x", uprobeRegexp.ReplaceAllString(path, "_"), addr)
 	return bpf.attachUProbe(evName, BPF_PROBE_RETURN, path, addr, fd, pid)
 }
 


### PR DESCRIPTION
AttachUretprobe must prefix with `r_`, not `p_` in order for uretprobes to work.

With this stupid patch, the probes are now correct (via perf probe -l)
```
$ sudo perf probe -l
  uprobes:p__usr_local_lib_XXX_bcc_XXX (on SomeFunction in /usr/local/lib/libXXX)
  uprobes:r__usr_local_lib_XXX_bcc_XXX (on SomeFunction%return in /usr/local/lib/libXXX)
```