### PR TITLE
pkg: Add Ksym helper

### DIFF
--- a/pkg/ksym/ksym.go
+++ b/pkg/ksym/ksym.go
@@ -1,0 +1,48 @@
+package ksym
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	KALLSYMS = "/proc/kallsyms"
+)
+
+// Ksym translates a kernel memory address into a kernel function name
+// using `/proc/kallsyms`
+func Ksym(addr string) (string, error) {
+	fd, err := os.Open(KALLSYMS)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+
+	fn := ksym(addr, fd)
+
+	if fn == "" {
+		return "", errors.New("kernel function not found for " + addr)
+	}
+
+	return fn, nil
+}
+
+func ksym(addr string, r io.Reader) string {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		l := s.Text()
+		ar := strings.Split(l, " ")
+		if len(ar) != 3 {
+			continue
+		}
+
+		if ar[0] == addr {
+			return ar[2]
+		}
+	}
+
+	return ""
+}

--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -1,0 +1,17 @@
+package ksym
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKsym(t *testing.T) {
+	data := "ffffffff91b2a340 T cgroup_freezing"
+
+	r := strings.NewReader(data)
+	fn := ksym("ffffffff91b2a340", r)
+
+	if fn != "cgroup_freezing" {
+		t.Error("unexpected result")
+	}
+}


### PR DESCRIPTION
This PR adds a helper to retrieve the name of a kernel function based on its address.

Context : to implement some monitoring tools I needed something like https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-ksym.

Not sure if reading `/proc/kallsyms` is the best way to do it. Please let me know.