### PR TITLE
bcc: make logging configurable

### DIFF
--- a/examples/bcc/xdp/xdp_drop.go
+++ b/examples/bcc/xdp/xdp_drop.go
@@ -132,12 +132,15 @@ func main() {
 	})
 	defer module.Close()
 
-	fn, err := module.Load("xdp_prog1", C.BPF_PROG_TYPE_XDP)
+	fn, err := module.Load("xdp_prog1", C.BPF_PROG_TYPE_XDP, 1, 65536)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load xdp prog: %v\n", err)
+		os.Exit(1)
+	}
 
 	err = module.AttachXDP(device, fn)
-
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "Failed to attach xdp prog: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Currently, logging is always enabled (log level `1`) and the log buffer
set to a fixed size of 65536 bytes. Since the log buffer must be large
enough for all verifier message when logging is enabled, the code
returns `ENOSPC` for larger programs and doesn't allow the user to
disable logging or increase the buffer.

Instead, disable bpf logging by default and allow the user to specify
log level and buffer size on `Load()`. This way, users can specify a
large enough buffer matching their program if desired.

Also, add a missing error check in `examples/bcc/xdp/xdp_drop.go`.

Resolves #103