### PR TITLE
semaphore: update kernels to test on

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -10,8 +10,8 @@
 set -eux
 set -o pipefail
 
-readonly kernel_versions=("4.4.45" "4.9.6" "4.10.6")
-readonly rkt_version="1.26.0"
+readonly kernel_versions=("4.4.114" "4.9.79" "4.14.16")
+readonly rkt_version="1.29.0"
 
 if [[ ! -f "./rkt/rkt" ]] \
   || [[ ! "$(./rkt/rkt version | awk '/rkt Version/{print $3}')" == "${rkt_version}" ]]; then


### PR DESCRIPTION
Use the latest longterm kernels.

Also, update the rkt version used to v1.29.