### PR TITLE
bcc.Table API: Use iterator instead of channel, provide raw byte-slices

### DIFF
--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -55,15 +55,7 @@ var mu sync.Mutex
 
 // In lack of binary.HostEndian ...
 func init() {
-	var i int32 = 0x01020304
-	u := unsafe.Pointer(&i)
-	pb := (*byte)(u)
-	b := *pb
-	if b == 0x04 {
-		byteOrder = binary.LittleEndian
-	} else {
-		byteOrder = binary.BigEndian
-	}
+	byteOrder = determineHostByteOrder()
 }
 
 func registerCallback(data *callbackData) uint64 {
@@ -99,6 +91,23 @@ func callback_to_go(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) 
 	go func() {
 		receiverChan <- C.GoBytes(raw, rawSize)
 	}()
+}
+
+// GetHostByteOrder returns the current byte-order.
+func GetHostByteOrder() binary.ByteOrder {
+	return byteOrder
+}
+
+func determineHostByteOrder() binary.ByteOrder {
+	var i int32 = 0x01020304
+	u := unsafe.Pointer(&i)
+	pb := (*byte)(u)
+	b := *pb
+	if b == 0x04 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
 }
 
 // InitPerfMap initializes a perf map with a receiver channel.

--- a/examples/bcc/xdp/xdp_drop.go
+++ b/examples/bcc/xdp/xdp_drop.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 
 	bpf "github.com/iovisor/gobpf/bcc"
 )
@@ -160,19 +159,9 @@ func main() {
 	<-sig
 
 	fmt.Printf("\n{IP protocol-number}: {total dropped pkts}\n")
-	for entry := range dropcnt.Iter() {
-		var key, value uint64
-		var err error
-
-		key, err = strconv.ParseUint(entry.Key, 0, 32)
-		if err != nil {
-			continue
-		}
-
-		value, err = strconv.ParseUint(entry.Value, 0, 64)
-		if err != nil {
-			continue
-		}
+	for it := dropcnt.Iter(); it.Next(); {
+		key := bpf.GetHostByteOrder().Uint32(it.Key())
+		value := bpf.GetHostByteOrder().Uint64(it.Leaf())
 
 		if value > 0 {
 			fmt.Printf("%v: %v pkts\n", key, value)


### PR DESCRIPTION
Currently `bcc.Table` provides iteration using a channel, a pattern that causes high overhead, and also always converts values to and from strings, which is inconvenient. This PR changes that API to a cursor-like iterator, providing a `Next()` method for iteration, and `Key()`, `Leaf()` to access the raw byte-slices, as well as `KeyString()`, `LeafString()` to continue supporting simple printing of table contents.

Note: Given that this is already a breaking API change, we'd offer to merge parts of @nathanleclaire's PR #102, which would change the regular `Get` and `Set` methods to use byte-slices as well.