### PR TITLE
Add ksym helper

### DIFF
--- a/pkg/ksym/ksym.go
+++ b/pkg/ksym/ksym.go
@@ -1,0 +1,66 @@
+package ksym
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	KALLSYMS = "/proc/kallsyms"
+)
+
+type ksymCache struct {
+	sync.RWMutex
+	ksym map[string]string
+}
+
+var cache ksymCache
+
+// Ksym translates a kernel memory address into a kernel function name
+// using `/proc/kallsyms`
+func Ksym(addr string) (string, error) {
+	if cache.ksym == nil {
+		cache.ksym = make(map[string]string)
+	}
+
+	cache.Lock()
+	defer cache.Unlock()
+
+	if _, ok := cache.ksym[addr]; !ok {
+		fd, err := os.Open(KALLSYMS)
+		if err != nil {
+			return "", err
+		}
+		defer fd.Close()
+
+		fn := ksym(addr, fd)
+		if fn == "" {
+			return "", errors.New("kernel function not found for " + addr)
+		}
+
+		cache.ksym[addr] = fn
+	}
+
+	return cache.ksym[addr], nil
+}
+
+func ksym(addr string, r io.Reader) string {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		l := s.Text()
+		ar := strings.Split(l, " ")
+		if len(ar) != 3 {
+			continue
+		}
+
+		if ar[0] == addr {
+			return ar[2]
+		}
+	}
+
+	return ""
+}

--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -1,0 +1,17 @@
+package ksym
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKsym(t *testing.T) {
+	data := "ffffffff91b2a340 T cgroup_freezing"
+
+	r := strings.NewReader(data)
+	fn := ksym("ffffffff91b2a340", r)
+
+	if fn != "cgroup_freezing" {
+		t.Error("unexpected result")
+	}
+}


### PR DESCRIPTION
This PR is based on https://github.com/iovisor/gobpf/pull/105 but adds the `Ksym` function in a helper package.

People found this kind of helpers pretty useful in the Python library. See : https://github.com/iovisor/gobpf/issues/113

cc @bobrik