### PR TITLE
elf: tracepoints: check section name

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -289,6 +289,9 @@ func (b *Module) EnableTracepoint(secName string) error {
 	progFd := prog.fd
 
 	tracepointGroup := strings.SplitN(secName, "/", 3)
+	if len(tracepointGroup) != 3 {
+		return fmt.Errorf("invalid section name %q, expected tracepoint/category/name", secName)
+	}
 	category := tracepointGroup[1]
 	name := tracepointGroup[2]
 


### PR DESCRIPTION
The section name is expected to have this naming:

SEC("tracepoint/raw_syscalls/sys_enter")

In case it doesn't, return an error.