### PR TITLE
Fix incompatible types in bpf_attach_perf_event

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -301,7 +301,7 @@ func (bpf *Module) AttachPerfEvent(evType, evConfig int, samplePeriod int, sampl
 	res := []int{}
 
 	if cpu > 0 {
-		r, err := C.bpf_attach_perf_event(C.int(fd), C.uint(evType), C.uint(evConfig), C.ulong(samplePeriod), C.ulong(sampleFreq), C.int(pid), C.int(cpu), C.int(groupFd))
+		r, err := C.bpf_attach_perf_event(C.int(fd), C.uint32_t(evType), C.uint32_t(evConfig), C.uint64_t(samplePeriod), C.uint64_t(sampleFreq), C.pid_t(pid), C.int(cpu), C.int(groupFd))
 		if r < 0 {
 			return fmt.Errorf("failed to attach BPF perf event: %v", err)
 		}
@@ -314,7 +314,7 @@ func (bpf *Module) AttachPerfEvent(evType, evConfig int, samplePeriod int, sampl
 		}
 
 		for _, i := range cpus {
-			r, err := C.bpf_attach_perf_event(C.int(fd), C.uint(evType), C.uint(evConfig), C.ulong(samplePeriod), C.ulong(sampleFreq), C.int(pid), C.int(i), C.int(groupFd))
+			r, err := C.bpf_attach_perf_event(C.int(fd), C.uint32_t(evType), C.uint32_t(evConfig), C.uint64_t(samplePeriod), C.uint64_t(sampleFreq), C.pid_t(pid), C.int(i), C.int(groupFd))
 			if r < 0 {
 				return fmt.Errorf("failed to attach BPF perf event: %v", err)
 			}


### PR DESCRIPTION
This updates the casts to be compatible with `bpf_attach_perf_event` in bcc: 

https://github.com/iovisor/bcc/blob/d83210da7876a3f70551372ed9c5ff83e639bcec/src/cc/libbpf.c#L1356

