### PR TITLE
bpffs: Allow to mount with custom mountpoint

### DIFF
--- a/pkg/bpffs/fs.go
+++ b/pkg/bpffs/fs.go
@@ -19,26 +19,36 @@ func init() {
 	FsMagicBPFFS = *(*int32)(unsafe.Pointer(&magic))
 }
 
-// IsMounted checks if the BPF fs is mounted already
-func IsMounted() (bool, error) {
+// IsMountedAt checks if the BPF fs is mounted already in the custom location
+func IsMountedAt(mountpoint string) (bool, error) {
 	var data syscall.Statfs_t
-	if err := syscall.Statfs(BPFFSPath, &data); err != nil {
-		return false, fmt.Errorf("cannot statfs %q: %v", BPFFSPath, err)
+	if err := syscall.Statfs(mountpoint, &data); err != nil {
+		return false, fmt.Errorf("cannot statfs %q: %v", mountpoint, err)
 	}
 	return int32(data.Type) == FsMagicBPFFS, nil
 }
 
-// Mount mounts the BPF fs if not already mounted
-func Mount() error {
-	mounted, err := IsMounted()
+// IsMounted checks if the BPF fs is mounted already in the default location
+func IsMounted() (bool, error) {
+	return IsMountedAt(BPFFSPath)
+}
+
+// MountAt mounts the BPF fs in the custom location (if not already mounted)
+func MountAt(mountpoint string) error {
+	mounted, err := IsMountedAt(mountpoint)
 	if err != nil {
 		return err
 	}
 	if mounted {
 		return nil
 	}
-	if err := syscall.Mount(BPFFSPath, BPFFSPath, "bpf", 0, ""); err != nil {
-		return fmt.Errorf("error mounting %q: %v", BPFFSPath, err)
+	if err := syscall.Mount(mountpoint, mountpoint, "bpf", 0, ""); err != nil {
+		return fmt.Errorf("error mounting %q: %v", mountpoint, err)
 	}
 	return nil
+}
+
+// Mount mounts the BPF fs in the default location (if not already mounted)
+func Mount() error {
+	return MountAt(BPFFSPath)
 }


### PR DESCRIPTION
The default mountpoint for BPFFS is /sys/fs/bpf, but mounting BPFFS
in the other locations is also possible. This change provides
additional functions which allow to do that.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>