### PR TITLE
bpf_test: don't skip when bpffs can't be mounted

### DIFF
--- a/bpf_test.go
+++ b/bpf_test.go
@@ -546,7 +546,7 @@ func TestModuleLoadELF(t *testing.T) {
 	}
 
 	if err := bpffs.Mount(); err != nil {
-		t.Skipf("error mounting bpf fs, skipping test: %v", err)
+		t.Fatalf("error mounting bpf fs: %v", err)
 	}
 
 	b := elf.NewModule(dummyELF)


### PR DESCRIPTION
As is, a failure during bpffs mount whould silently skip all elf tests
and make the test run look successful judging from its status.