### PR TITLE
bcc/symbol.go: fixes a cgo type conversion in bccResolveName

### DIFF
--- a/bcc/symbol.go
+++ b/bcc/symbol.go
@@ -104,7 +104,7 @@ func bccResolveName(module, symname string, pid int) (uint64, error) {
 	defer C.free(unsafe.Pointer(nameCS))
 
 	var addr uint64
-	addrC := C.ulong(addr)
+	addrC := C.uint64_t(addr)
 	res := C.bcc_symcache_resolve_name(cache, moduleCS, nameCS, &addrC)
 	if res < 0 {
 		return 0, fmt.Errorf("unable to locate symbol %s in module %s", symname, module)


### PR DESCRIPTION
Hi folks,
Builds are now failing with the following error:
```
# github.com/iovisor/gobpf/bcc
./symbol.go:108: cannot use &addrC (type *C.ulong) as type *C.uint64_t in argument to func literal
```
This PR is just a small fix for a type conversion of an argument of libbcc's `bcc_symcache_resolve_name`. The correct type is a pointer to `unit64_t`:
https://github.com/iovisor/bcc/blob/master/src/cc/bcc_syms.h#L56-L57

Best.