### PR TITLE
Implement GetProgramTag

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -161,6 +161,12 @@ func (bpf *Module) Close() {
 	}
 }
 
+// GetProgramTag returns a tag for ebpf program under passed fd
+func (bpf *Module) GetProgramTag(fd int) (tag uint64, err error) {
+	_, err = C.bpf_prog_get_tag(C.int(fd), (*C.ulonglong)(unsafe.Pointer(&tag)))
+	return tag, err
+}
+
 // LoadNet loads a program of type BPF_PROG_TYPE_SCHED_ACT.
 func (bpf *Module) LoadNet(name string) (int, error) {
 	return bpf.Load(name, C.BPF_PROG_TYPE_SCHED_ACT, 0, 0)


### PR DESCRIPTION
This can be used with `perf` when `net.core.bpf_jit_kallsyms=1`
and `--kallsyms=/proc/kallsyms` are passed to `perf record`.

On newer kernels `perf top` can also accept `--kallsyms`:

* https://www.spinics.net/lists/linux-perf-users/msg07216.html

See: https://github.com/cloudflare/ebpf_exporter/issues/39