### PR TITLE
elf: allow to override max_entries for BPFMap

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -369,6 +369,13 @@ func elfReadMaps(file *elf.File, params map[string]SectionParams) (map[string]*M
 
 		mapDef := (*C.bpf_map_def)(unsafe.Pointer(&data[0]))
 
+		// check if the map size has to be changed
+		if p, ok := params[section.Name]; ok {
+			if p.MapMaxEntries != 0 {
+				mapDef.max_entries = C.uint(p.MapMaxEntries)
+			}
+		}
+
 		mapPath, err := createMapPath(mapDef, name, params[section.Name])
 		if err != nil {
 			return nil, err
@@ -469,6 +476,7 @@ type SectionParams struct {
 	PerfRingBufferPageCount   int
 	SkipPerfMapInitialization bool
 	PinPath                   string // path to be pinned, relative to "/sys/fs/bpf"
+	MapMaxEntries             int    // Used to override bpf map entries size
 }
 
 // Load loads the BPF programs and BPF maps in the module. Each ELF section


### PR DESCRIPTION
Allow to override max_entries for BPFMap through BPFMapMaxEntries SectionParams attribute.

In the case where we want to store network connections in a BPF Map, what we could do would be to get the maximum number of connections that can be running on the given host and use it to set the BPF map size.