### PR TITLE
elf: add implementation to loop sched progs

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -572,6 +572,19 @@ func (up *Uprobe) Fd() int {
 	return up.fd
 }
 
+// IterSchedProgram returns a channel that emits the sched programs included in the
+// module.
+func (b *Module) IterSchedProgram() <-chan *SchedProgram {
+	ch := make(chan *SchedProgram)
+	go func() {
+		for name := range b.schedPrograms {
+			ch <- b.schedPrograms[name]
+		}
+		close(ch)
+	}()
+	return ch
+}
+
 func (b *Module) SchedProgram(name string) *SchedProgram {
 	return b.schedPrograms[name]
 }


### PR DESCRIPTION
**Issue:** users of the elf module api are not able to loop over sched progs. The'd have to know the program name upfront.

This PR offers an func that returns a channel that emits the sched programs included in the module. Just like the other `Iter*` funcs.

Users have the very same issue with accessing maps. Would you like to have that added aswell?