### PR TITLE
Update gobpf to match the changes merged into upstream bcc

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -29,7 +29,7 @@ import (
 /*
 #cgo CFLAGS: -I/usr/include/bcc/compat
 #cgo LDFLAGS: -lbcc
-#include <bcc/bpf_common.h>
+#include <bcc/bcc_common.h>
 #include <bcc/libbpf.h>
 */
 import "C"

--- a/bcc/module.go
+++ b/bcc/module.go
@@ -95,7 +95,10 @@ func newModule(code string, cflags []string) *Module {
 	}
 	cs := C.CString(code)
 	defer C.free(unsafe.Pointer(cs))
-	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)))
+
+	// pass false for allowRLimit for simplicity
+	// TODO allow passing this flag through somehow
+	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)), C.bool(false))
 	if c == nil {
 		return nil
 	}

--- a/bcc/module.go
+++ b/bcc/module.go
@@ -227,7 +227,7 @@ func (bpf *Module) load(name string, progType int, logLevel, logSize uint) (int,
 		logBuf = make([]byte, logSize)
 		logBufP = (*C.char)(unsafe.Pointer(&logBuf[0]))
 	}
-	fd, err := C.bpf_prog_load(uint32(progType), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)))
+	fd, err := C.bcc_prog_load(uint32(progType), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)))
 	if fd < 0 {
 		return -1, fmt.Errorf("error loading BPF program: %v", err)
 	}

--- a/bcc/module.go
+++ b/bcc/module.go
@@ -237,14 +237,14 @@ func (bpf *Module) load(name string, progType int, logLevel, logSize uint) (int,
 var kprobeRegexp = regexp.MustCompile("[+.]")
 var uprobeRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
 
-func (bpf *Module) attachProbe(evName string, attachType uint32, fnName string, fd int) error {
+func (bpf *Module) attachProbe(evName string, attachType uint32, fnName string, fd int, maxActive int) error {
 	if _, ok := bpf.kprobes[evName]; ok {
 		return nil
 	}
 
 	evNameCS := C.CString(evName)
 	fnNameCS := C.CString(fnName)
-	res, err := C.bpf_attach_kprobe(C.int(fd), attachType, evNameCS, fnNameCS, (C.uint64_t)(0))
+	res, err := C.bpf_attach_kprobe(C.int(fd), attachType, evNameCS, fnNameCS, (C.uint64_t)(0), C.int(maxActive))
 	C.free(unsafe.Pointer(evNameCS))
 	C.free(unsafe.Pointer(fnNameCS))
 
@@ -270,17 +270,17 @@ func (bpf *Module) attachUProbe(evName string, attachType uint32, path string, a
 }
 
 // AttachKprobe attaches a kprobe fd to a function.
-func (bpf *Module) AttachKprobe(fnName string, fd int) error {
+func (bpf *Module) AttachKprobe(fnName string, fd int, maxActive int) error {
 	evName := "p_" + kprobeRegexp.ReplaceAllString(fnName, "_")
 
-	return bpf.attachProbe(evName, BPF_PROBE_ENTRY, fnName, fd)
+	return bpf.attachProbe(evName, BPF_PROBE_ENTRY, fnName, fd, maxActive)
 }
 
 // AttachKretprobe attaches a kretprobe fd to a function.
-func (bpf *Module) AttachKretprobe(fnName string, fd int) error {
+func (bpf *Module) AttachKretprobe(fnName string, fd int, maxActive int) error {
 	evName := "r_" + kprobeRegexp.ReplaceAllString(fnName, "_")
 
-	return bpf.attachProbe(evName, BPF_PROBE_RETURN, fnName, fd)
+	return bpf.attachProbe(evName, BPF_PROBE_RETURN, fnName, fd, maxActive)
 }
 
 // AttachTracepoint attaches a tracepoint fd to a function

--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -26,7 +26,7 @@ import (
 /*
 #cgo CFLAGS: -I/usr/include/bcc/compat
 #cgo LDFLAGS: -lbcc
-#include <bcc/bpf_common.h>
+#include <bcc/bcc_common.h>
 #include <bcc/libbpf.h>
 #include <bcc/perf_reader.h>
 

--- a/bcc/symbol.go
+++ b/bcc/symbol.go
@@ -24,7 +24,7 @@ import (
 /*
 #cgo CFLAGS: -I/usr/include/bcc/compat
 #cgo LDFLAGS: -lbcc
-#include <bcc/bpf_common.h>
+#include <bcc/bcc_common.h>
 #include <bcc/libbpf.h>
 #include <bcc/bcc_syms.h>
 extern void foreach_symbol_callback(char*, uint64_t);

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -25,7 +25,7 @@ import (
 /*
 #cgo CFLAGS: -I/usr/include/bcc/compat
 #cgo LDFLAGS: -lbcc
-#include <bcc/bpf_common.h>
+#include <bcc/bcc_common.h>
 #include <bcc/libbpf.h>
 */
 import "C"

--- a/elf/elf.go
+++ b/elf/elf.go
@@ -76,7 +76,7 @@ static void bpf_apply_relocation(int fd, struct bpf_insn *insn)
 	insn->imm = fd;
 }
 
-static int bpf_create_map(enum bpf_map_type map_type, int key_size,
+static int bcc_create_map(enum bpf_map_type map_type, int key_size,
 	int value_size, int max_entries)
 {
 	int ret;
@@ -158,7 +158,7 @@ static bpf_map *bpf_load_map(bpf_map_def *map_def, const char *path)
 		do_pin = 1;
 	}
 
-	map->fd = bpf_create_map(map_def->type,
+	map->fd = bcc_create_map(map_def->type,
 		map_def->key_size,
 		map_def->value_size,
 		map_def->max_entries
@@ -178,7 +178,7 @@ static bpf_map *bpf_load_map(bpf_map_def *map_def, const char *path)
 	return map;
 }
 
-static int bpf_prog_load(enum bpf_prog_type prog_type,
+static int bcc_prog_load(enum bpf_prog_type prog_type,
 	const struct bpf_insn *insns, int prog_len,
 	const char *license, int kern_version,
 	char *log_buf, int log_size)
@@ -598,7 +598,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 
 				insns := (*C.struct_bpf_insn)(unsafe.Pointer(&rdata[0]))
 
-				progFd, err := C.bpf_prog_load(progType,
+				progFd, err := C.bcc_prog_load(progType,
 					insns, C.int(rsection.Size),
 					(*C.char)(lp), C.int(version),
 					(*C.char)(unsafe.Pointer(&b.log[0])), C.int(len(b.log)))
@@ -712,7 +712,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 
 			insns := (*C.struct_bpf_insn)(unsafe.Pointer(&data[0]))
 
-			progFd, err := C.bpf_prog_load(progType,
+			progFd, err := C.bcc_prog_load(progType,
 				insns, C.int(section.Size),
 				(*C.char)(lp), C.int(version),
 				(*C.char)(unsafe.Pointer(&b.log[0])), C.int(len(b.log)))

--- a/elf/include/bpf.h
+++ b/elf/include/bpf.h
@@ -9,7 +9,7 @@
 #define _UAPI__LINUX_BPF_H__
 
 #include <linux/types.h>
-#include <linux/bpf_common.h>
+#include <linux/bcc_common.h>
 
 /* Extended instruction set based on top of classic BPF */
 

--- a/examples/bcc/execsnoop/execsnoop.go
+++ b/examples/bcc/execsnoop/execsnoop.go
@@ -204,7 +204,9 @@ func run() {
 		os.Exit(1)
 	}
 
-	if err := m.AttachKprobe(fnName, kprobe); err != nil {
+	// passing -1 for maxActive signifies to use the default
+	// according to the kernel kprobes documentation
+	if err := m.AttachKprobe(fnName, kprobe, -1); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to attach syscall__execve: %s\n", err)
 		os.Exit(1)
 	}
@@ -215,7 +217,9 @@ func run() {
 		os.Exit(1)
 	}
 
-	if err := m.AttachKretprobe(fnName, kretprobe); err != nil {
+	// passing -1 for maxActive signifies to use the default
+	// according to the kernel kretprobes documentation
+	if err := m.AttachKretprobe(fnName, kretprobe, -1); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to attach do_ret_sys_execve: %s\n", err)
 		os.Exit(1)
 	}

--- a/examples/bcc/perf/perf.go
+++ b/examples/bcc/perf/perf.go
@@ -92,7 +92,9 @@ func main() {
 
 	syscallName := bpf.GetSyscallFnName("fchownat")
 
-	err = m.AttachKprobe(syscallName, chownKprobe)
+	// passing -1 for maxActive signifies to use the default
+	// according to the kernel kprobes documentation
+	err = m.AttachKprobe(syscallName, chownKprobe, -1)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to attach kprobe__sys_fchownat: %s\n", err)
 		os.Exit(1)
@@ -104,7 +106,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = m.AttachKretprobe(syscallName, chownKretprobe)
+	// passing -1 for maxActive signifies to use the default
+	// according to the kernel kretprobes documentation
+	err = m.AttachKretprobe(syscallName, chownKretprobe, -1)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to attach kretprobe__sys_fchownat: %s\n", err)
 		os.Exit(1)

--- a/examples/bcc/xdp/xdp_drop.go
+++ b/examples/bcc/xdp/xdp_drop.go
@@ -18,7 +18,7 @@ import (
 /*
 #cgo CFLAGS: -I/usr/include/bcc/compat
 #cgo LDFLAGS: -lbcc
-#include <bcc/bpf_common.h>
+#include <bcc/bcc_common.h>
 #include <bcc/libbpf.h>
 void perf_reader_free(void *ptr);
 */


### PR DESCRIPTION
bcc has gotten a bunch of dev support over the last few months and they just released an update [yesterday](https://github.com/iovisor/bcc/releases). This PR updates the CGo bindings in gobpf to actually compile with the latest bcc. Each commit message includes the bcc commit that it addresses.

Currently, `go get github.com/iovisor/gobpf/bcc` fails with:
```
$ go get github.com/iovisor/gobpf/bcc
# github.com/iovisor/gobpf/bcc
go/src/github.com/iovisor/gobpf/bcc/module.go:32:28: fatal error: bcc/bpf_common.h: No such file or directory
compilation terminated.
```