### PR TITLE
elf: TracepointProgram: add Fd()

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -420,6 +420,10 @@ func (p *CgroupProgram) Fd() int {
 	return p.fd
 }
 
+func (tp *TracepointProgram) Fd() int {
+	return tp.fd
+}
+
 var safeEventRegexp = regexp.MustCompile("[^a-zA-Z0-9]")
 
 func safeEventName(event string) string {


### PR DESCRIPTION
Add getter function to get the file descriptor of a tracepoint program.
It can be used in the following way:

```
for tp := range m.IterTracepointProgram() {
  fmt.Printf("name: %s fd=%d\n", tp.Name, tp.Fd())
}
```