### PR TITLE
[elf] LookupNextElement should not return an error on ENOENT 

### DIFF
--- a/bpf_test.go
+++ b/bpf_test.go
@@ -556,13 +556,13 @@ func checkLookupElement(t *testing.T, b *elf.Module) {
 
 	key = 0
 	nextKey := 0
-	for range found {
+	for {
 		f, err := b.LookupNextElement(mp, unsafe.Pointer(&key), unsafe.Pointer(&nextKey), unsafe.Pointer(&lvalue))
 		if err != nil {
-			t.Fatal("failed trying to lookup the next element")
+			t.Fatalf("failed trying to lookup the next element: %s", err)
 		}
 		if !f {
-			t.Fatalf("unable to find key %d", key)
+			break
 		}
 
 		if nextKey != lvalue {

--- a/elf/table.go
+++ b/elf/table.go
@@ -158,6 +158,9 @@ func (b *Module) LookupNextElement(mp *Map, key, nextKey, value unsafe.Pointer) 
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	if err == syscall.ENOENT {
+		return false, nil
+	}
 	if err != 0 {
 		return false, fmt.Errorf("unable to find next element: %s", err)
 	}


### PR DESCRIPTION
Per the [documentation](http://man7.org/linux/man-pages/man2/bpf.2.html) on `BPF_MAP_GET_NEXT_KEY `:

> If key is found, the operation returns zero and sets the
              next_key pointer to the key of the next element.  If key is
              not found, the operation returns zero and sets the next_key
              pointer to the key of the first element.  If key is the last
              element, -1 is returned and errno is set to ENOENT.  Other
              possible errno values are ENOMEM, EFAULT, EPERM, and EINVAL.
              This method can be used to iterate over all elements in the
              map.

This PR fixes `LookupNextElement` to not return an error when `ENOENT` is received. 

We noticed that the errors being created here were a minor, but persistent, source of allocations in our application.

We're also seeing similar allocation patterns in `LookupElement` / `DeleteElement` where it returns an error if the element is not found.  Ideally, these would return `(bool, error)` to indicate if the element was not found or if there was a genuine error performing the operation.  I'm happy to make those changes but I understand if you don't want to do so given that it would be a breaking change.