### PR TITLE
Support for XDP programs in ELF object files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ sections (`SEC("...")`). The following are currently supported:
 * `maps/...`
 * `socket...`
 * `tracepoint...`
-* `uprobe/...` and `uretprobe/...`
+* `uprobe/...`
+* `uretprobe/...`
+* `xdp/...`
 
 Map definitions must correspond to `bpf_map_def` from [the elf package](https://github.com/iovisor/gobpf/blob/master/elf/include/bpf_map.h).
 Otherwise, you will encounter an error like `only one map with size 280 bytes allowed per section (check bpf_map_def)`.

--- a/bpf_test.go
+++ b/bpf_test.go
@@ -412,6 +412,26 @@ func checkCgroupProgs(t *testing.T, b *elf.Module) {
 	}
 }
 
+func checkXDPProgs(t *testing.T, b *elf.Module) {
+	if kernelVersion < kernelVersion412 {
+		t.Logf("kernel doesn't support XDP. Skipping...")
+		t.Skip()
+	}
+
+	var expectedXDPProgs = []string{
+		"xdp/prog1",
+		"xdp/prog2",
+	}
+
+	var xdpProgs []*elf.XDPProgram
+	for p := range b.IterXDPProgram() {
+		xdpProgs = append(xdpProgs, p)
+	}
+	if len(xdpProgs) != len(expectedXDPProgs) {
+		t.Fatalf("unexpected number of XDP programs. Got %d, expected %v", len(xdpProgs), len(expectedXDPProgs))
+	}
+}
+
 func checkTracepointProgs(t *testing.T, b *elf.Module) {
 	if kernelVersion < kernelVersion47 {
 		t.Logf("kernel doesn't support bpf programs for tracepoints. Skipping...")
@@ -656,6 +676,7 @@ func TestModuleLoadELF(t *testing.T) {
 	checkCgroupProgs(t, b)
 	checkSocketFilters(t, b)
 	checkTracepointProgs(t, b)
+	checkXDPProgs(t, b)
 	checkPinConfig(t, []string{"/sys/fs/bpf/gobpf-test/testgroup1"})
 	checkUpdateDeleteElement(t, b)
 	checkLookupElement(t, b)

--- a/elf/elf.go
+++ b/elf/elf.go
@@ -563,6 +563,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 			isSchedCls := strings.HasPrefix(secName, "sched_cls/")
 			isSchedAct := strings.HasPrefix(secName, "sched_act/")
+			isXDP := strings.HasPrefix(secName, "xdp/")
 
 			var progType uint32
 			switch {
@@ -587,6 +588,8 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				progType = uint32(C.BPF_PROG_TYPE_SCHED_CLS)
 			case isSchedAct:
 				progType = uint32(C.BPF_PROG_TYPE_SCHED_ACT)
+			case isXDP:
+				progType = uint32(C.BPF_PROG_TYPE_XDP)
 			}
 
 			// If Kprobe or Kretprobe for a syscall, use correct syscall prefix in section name
@@ -602,7 +605,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				}
 			}
 
-			if isKprobe || isKretprobe || isUprobe || isUretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct {
+			if isKprobe || isKretprobe || isUprobe || isUretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct || isXDP {
 				rdata, err := rsection.Data()
 				if err != nil {
 					return err
@@ -674,6 +677,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						insns: insns,
 						fd:    int(progFd),
 					}
+				case isXDP:
+					b.xdpPrograms[secName] = &XDPProgram{
+						Name: secName,
+						insns: insns,
+						fd: int(progFd),
+					}
 				}
 			}
 		}
@@ -696,6 +705,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 		isSchedCls := strings.HasPrefix(secName, "sched_cls/")
 		isSchedAct := strings.HasPrefix(secName, "sched_act/")
+		isXDP := strings.HasPrefix(secName, "xdp/")
 
 		var progType uint32
 		switch {
@@ -719,6 +729,8 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			progType = uint32(C.BPF_PROG_TYPE_SCHED_CLS)
 		case isSchedAct:
 			progType = uint32(C.BPF_PROG_TYPE_SCHED_ACT)
+		case isXDP:
+			progType = uint32(C.BPF_PROG_TYPE_XDP)
 		}
 
 		// If Kprobe or Kretprobe for a syscall, use correct syscall prefix in section name
@@ -734,7 +746,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			}
 		}
 
-		if isKprobe || isKretprobe || isUprobe || isUretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct {
+		if isKprobe || isKretprobe || isUprobe || isUretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct || isXDP {
 			data, err := section.Data()
 			if err != nil {
 				return err
@@ -800,6 +812,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),
+				}
+			case isXDP:
+				b.xdpPrograms[secName] = &XDPProgram{
+					Name: secName,
+					insns: insns,
+					fd: int(progFd),
 				}
 			}
 		}

--- a/elf/include/libbpf.h
+++ b/elf/include/libbpf.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+/*
+ * Common eBPF ELF object loading operations.
+ *
+ * Copyright (C) 2013-2015 Alexei Starovoitov <ast@kernel.org>
+ * Copyright (C) 2015 Wang Nan <wangnan0@huawei.com>
+ * Copyright (C) 2015 Huawei Inc.
+ */
+
+#ifndef __LIBBPF_LIBBPF_H
+#define __LIBBPF_LIBBPF_H
+
+#include <stdint.h>
+#include <linux/netlink.h>
+
+enum libbpf_errno {
+	__LIBBPF_ERRNO__START = 4000,
+
+	/* Something wrong in libelf */
+	LIBBPF_ERRNO__LIBELF = __LIBBPF_ERRNO__START,
+	LIBBPF_ERRNO__FORMAT,	/* BPF object format invalid */
+	LIBBPF_ERRNO__KVERSION,	/* Incorrect or no 'version' section */
+	LIBBPF_ERRNO__ENDIAN,	/* Endian mismatch */
+	LIBBPF_ERRNO__INTERNAL,	/* Internal error in libbpf */
+	LIBBPF_ERRNO__RELOC,	/* Relocation failed */
+	LIBBPF_ERRNO__LOAD,	/* Load program failure for unknown reason */
+	LIBBPF_ERRNO__VERIFY,	/* Kernel verifier blocks program loading */
+	LIBBPF_ERRNO__PROG2BIG,	/* Program too big */
+	LIBBPF_ERRNO__KVER,	/* Incorrect kernel version */
+	LIBBPF_ERRNO__PROGTYPE,	/* Kernel doesn't support this program type */
+	LIBBPF_ERRNO__WRNGPID,	/* Wrong pid in netlink message */
+	LIBBPF_ERRNO__INVSEQ,	/* Invalid netlink sequence */
+	LIBBPF_ERRNO__NLPARSE,	/* netlink parsing error */
+	__LIBBPF_ERRNO__END,
+};
+
+typedef int (*libbpf_dump_nlmsg_t)(void *cookie, void *msg, struct nlattr **tb);
+
+#endif /* __LIBBPF_LIBBPF_H */

--- a/elf/include/nlattr.h
+++ b/elf/include/nlattr.h
@@ -1,0 +1,106 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+/*
+ * NETLINK      Netlink attributes
+ *
+ * Copyright (c) 2003-2013 Thomas Graf <tgraf@suug.ch>
+ */
+
+#ifndef __LIBBPF_NLATTR_H
+#define __LIBBPF_NLATTR_H
+
+#include <stdint.h>
+#include <linux/netlink.h>
+/* avoid multiple definition of netlink features */
+#define __LINUX_NETLINK_H
+
+/**
+ * Standard attribute types to specify validation policy
+ */
+enum {
+	LIBBPF_NLA_UNSPEC,	/**< Unspecified type, binary data chunk */
+	LIBBPF_NLA_U8,		/**< 8 bit integer */
+	LIBBPF_NLA_U16,		/**< 16 bit integer */
+	LIBBPF_NLA_U32,		/**< 32 bit integer */
+	LIBBPF_NLA_U64,		/**< 64 bit integer */
+	LIBBPF_NLA_STRING,	/**< NUL terminated character string */
+	LIBBPF_NLA_FLAG,	/**< Flag */
+	LIBBPF_NLA_MSECS,	/**< Micro seconds (64bit) */
+	LIBBPF_NLA_NESTED,	/**< Nested attributes */
+	__LIBBPF_NLA_TYPE_MAX,
+};
+
+#define LIBBPF_NLA_TYPE_MAX (__LIBBPF_NLA_TYPE_MAX - 1)
+
+/**
+ * @ingroup attr
+ * Attribute validation policy.
+ *
+ * See section @core_doc{core_attr_parse,Attribute Parsing} for more details.
+ */
+struct libbpf_nla_policy {
+	/** Type of attribute or LIBBPF_NLA_UNSPEC */
+	uint16_t	type;
+
+	/** Minimal length of payload required */
+	uint16_t	minlen;
+
+	/** Maximal length of payload allowed */
+	uint16_t	maxlen;
+};
+
+/**
+ * @ingroup attr
+ * Iterate over a stream of attributes
+ * @arg pos	loop counter, set to current attribute
+ * @arg head	head of attribute stream
+ * @arg len	length of attribute stream
+ * @arg rem	initialized to len, holds bytes currently remaining in stream
+ */
+#define libbpf_nla_for_each_attr(pos, head, len, rem) \
+	for (pos = head, rem = len; \
+	     nla_ok(pos, rem); \
+	     pos = nla_next(pos, &(rem)))
+
+/**
+ * libbpf_nla_data - head of payload
+ * @nla: netlink attribute
+ */
+static inline void *libbpf_nla_data(const struct nlattr *nla)
+{
+	return (char *) nla + NLA_HDRLEN;
+}
+
+static inline uint8_t libbpf_nla_getattr_u8(const struct nlattr *nla)
+{
+	return *(uint8_t *)libbpf_nla_data(nla);
+}
+
+static inline uint32_t libbpf_nla_getattr_u32(const struct nlattr *nla)
+{
+	return *(uint32_t *)libbpf_nla_data(nla);
+}
+
+static inline const char *libbpf_nla_getattr_str(const struct nlattr *nla)
+{
+	return (const char *)libbpf_nla_data(nla);
+}
+
+/**
+ * libbpf_nla_len - length of payload
+ * @nla: netlink attribute
+ */
+static inline int libbpf_nla_len(const struct nlattr *nla)
+{
+	return nla->nla_len - NLA_HDRLEN;
+}
+
+int libbpf_nla_parse(struct nlattr *tb[], int maxtype, struct nlattr *head,
+		     int len, struct libbpf_nla_policy *policy);
+int libbpf_nla_parse_nested(struct nlattr *tb[], int maxtype,
+			    struct nlattr *nla,
+			    struct libbpf_nla_policy *policy);
+
+int libbpf_nla_dump_errormsg(struct nlmsghdr *nlh);
+
+#endif /* __LIBBPF_NLATTR_H */

--- a/elf/lib/netlink.c
+++ b/elf/lib/netlink.c
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2018 Facebook */
+
+#include <stdlib.h>
+#include <memory.h>
+#include <unistd.h>
+#include <linux/rtnetlink.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <time.h>
+
+#include "include/bpf.h"
+#include "include/libbpf.h"
+#include "include/nlattr.h"
+
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+
+typedef int (*__dump_nlmsg_t)(struct nlmsghdr *nlmsg, libbpf_dump_nlmsg_t,
+			      void *cookie);
+
+static int bpf_netlink_recv(int sock, __u32 nl_pid, int seq,
+			    __dump_nlmsg_t _fn, libbpf_dump_nlmsg_t fn,
+			    void *cookie)
+{
+	bool multipart = true;
+	struct nlmsgerr *err;
+	struct nlmsghdr *nh;
+	char buf[4096];
+	int len, ret;
+
+	while (multipart) {
+		multipart = false;
+		len = recv(sock, buf, sizeof(buf), 0);
+		if (len < 0) {
+			ret = -errno;
+			goto done;
+		}
+
+		if (len == 0)
+			break;
+
+		for (nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, len);
+		     nh = NLMSG_NEXT(nh, len)) {
+			if (nh->nlmsg_pid != nl_pid) {
+				ret = -LIBBPF_ERRNO__WRNGPID;
+				goto done;
+			}
+			if (nh->nlmsg_seq != seq) {
+				ret = -LIBBPF_ERRNO__INVSEQ;
+				goto done;
+			}
+			if (nh->nlmsg_flags & NLM_F_MULTI)
+				multipart = true;
+			switch (nh->nlmsg_type) {
+			case NLMSG_ERROR:
+				err = (struct nlmsgerr *)NLMSG_DATA(nh);
+				if (!err->error)
+					continue;
+				ret = err->error;
+				libbpf_nla_dump_errormsg(nh);
+				goto done;
+			case NLMSG_DONE:
+				return 0;
+			default:
+				break;
+			}
+			if (_fn) {
+				ret = _fn(nh, fn, cookie);
+				if (ret)
+					return ret;
+			}
+		}
+	}
+	ret = 0;
+done:
+	return ret;
+}
+
+int libbpf_netlink_open(__u32 *nl_pid)
+{
+	struct sockaddr_nl sa;
+	socklen_t addrlen;
+	int one = 1, ret;
+	int sock;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.nl_family = AF_NETLINK;
+
+	sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (sock < 0)
+		return -errno;
+
+	if (setsockopt(sock, SOL_NETLINK, NETLINK_EXT_ACK,
+		       &one, sizeof(one)) < 0) {
+		fprintf(stderr, "Netlink error reporting not supported\n");
+	}
+
+	if (bind(sock, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+		ret = -errno;
+		goto cleanup;
+	}
+
+	addrlen = sizeof(sa);
+	if (getsockname(sock, (struct sockaddr *)&sa, &addrlen) < 0) {
+		ret = -errno;
+		goto cleanup;
+	}
+
+	if (addrlen != sizeof(sa)) {
+		ret = -LIBBPF_ERRNO__INTERNAL;
+		goto cleanup;
+	}
+
+	*nl_pid = sa.nl_pid;
+	return sock;
+
+cleanup:
+	close(sock);
+	return ret;
+}
+
+int bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags)
+{
+	int sock, seq = 0, ret;
+	struct nlattr *nla, *nla_xdp;
+	struct {
+		struct nlmsghdr  nh;
+		struct ifinfomsg ifinfo;
+		char             attrbuf[64];
+	} req;
+	__u32 nl_pid;
+
+	sock = libbpf_netlink_open(&nl_pid);
+	if (sock < 0)
+		return sock;
+
+	memset(&req, 0, sizeof(req));
+	req.nh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+	req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	req.nh.nlmsg_type = RTM_SETLINK;
+	req.nh.nlmsg_pid = 0;
+	req.nh.nlmsg_seq = ++seq;
+	req.ifinfo.ifi_family = AF_UNSPEC;
+	req.ifinfo.ifi_index = ifindex;
+
+	nla = (struct nlattr *)(((char *)&req) + NLMSG_ALIGN(req.nh.nlmsg_len));
+	nla->nla_type = NLA_F_NESTED | IFLA_XDP;
+	nla->nla_len = NLA_HDRLEN;
+
+	nla_xdp = (struct nlattr *)((char *)nla + nla->nla_len);
+	nla_xdp->nla_type = IFLA_XDP_FD;
+	nla_xdp->nla_len = NLA_HDRLEN + sizeof(int);
+	memcpy((char *)nla_xdp + NLA_HDRLEN, &fd, sizeof(fd));
+	nla->nla_len += nla_xdp->nla_len;
+
+	if (flags) {
+  		nla_xdp = (struct nlattr *)((char *)nla + nla->nla_len);
+  		nla_xdp->nla_type = IFLA_XDP_FLAGS;
+  		nla_xdp->nla_len = NLA_HDRLEN + sizeof(flags);
+  		memcpy((char *)nla_xdp + NLA_HDRLEN, &flags, sizeof(flags));
+  		nla->nla_len += nla_xdp->nla_len;
+	}
+
+	req.nh.nlmsg_len += NLA_ALIGN(nla->nla_len);
+
+	if (send(sock, &req, req.nh.nlmsg_len, 0) < 0) {
+  		ret = -errno;
+   		goto cleanup;
+	}
+	ret = bpf_netlink_recv(sock, nl_pid, seq, NULL, NULL, NULL);
+
+cleanup:
+    close(sock);
+    return ret;
+}
+

--- a/elf/lib/nlattr.c
+++ b/elf/lib/nlattr.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+/*
+ * NETLINK      Netlink attributes
+ *
+ * Copyright (c) 2003-2013 Thomas Graf <tgraf@suug.ch>
+ */
+
+#include <errno.h>
+#include "include/nlattr.h"
+#include <linux/rtnetlink.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef int (*__dump_nlmsg_t)(struct nlmsghdr *nlmsg, libbpf_dump_nlmsg_t,
+			      void *cookie);
+
+static uint16_t nla_attr_minlen[LIBBPF_NLA_TYPE_MAX+1] = {
+	[LIBBPF_NLA_U8]		= sizeof(uint8_t),
+	[LIBBPF_NLA_U16]	= sizeof(uint16_t),
+	[LIBBPF_NLA_U32]	= sizeof(uint32_t),
+	[LIBBPF_NLA_U64]	= sizeof(uint64_t),
+	[LIBBPF_NLA_STRING]	= 1,
+	[LIBBPF_NLA_FLAG]	= 0,
+};
+
+static struct nlattr *nla_next(const struct nlattr *nla, int *remaining)
+{
+	int totlen = NLA_ALIGN(nla->nla_len);
+
+	*remaining -= totlen;
+	return (struct nlattr *) ((char *) nla + totlen);
+}
+
+static int nla_ok(const struct nlattr *nla, int remaining)
+{
+	return remaining >= sizeof(*nla) &&
+	       nla->nla_len >= sizeof(*nla) &&
+	       nla->nla_len <= remaining;
+}
+
+static int nla_type(const struct nlattr *nla)
+{
+	return nla->nla_type & NLA_TYPE_MASK;
+}
+
+static int validate_nla(struct nlattr *nla, int maxtype,
+			struct libbpf_nla_policy *policy)
+{
+	struct libbpf_nla_policy *pt;
+	unsigned int minlen = 0;
+	int type = nla_type(nla);
+
+	if (type < 0 || type > maxtype)
+		return 0;
+
+	pt = &policy[type];
+
+	if (pt->type > LIBBPF_NLA_TYPE_MAX)
+		return 0;
+
+	if (pt->minlen)
+		minlen = pt->minlen;
+	else if (pt->type != LIBBPF_NLA_UNSPEC)
+		minlen = nla_attr_minlen[pt->type];
+
+	if (libbpf_nla_len(nla) < minlen)
+		return -1;
+
+	if (pt->maxlen && libbpf_nla_len(nla) > pt->maxlen)
+		return -1;
+
+	if (pt->type == LIBBPF_NLA_STRING) {
+		char *data = libbpf_nla_data(nla);
+
+		if (data[libbpf_nla_len(nla) - 1] != '\0')
+			return -1;
+	}
+
+	return 0;
+}
+
+static inline int nlmsg_len(const struct nlmsghdr *nlh)
+{
+	return nlh->nlmsg_len - NLMSG_HDRLEN;
+}
+
+/**
+ * Create attribute index based on a stream of attributes.
+ * @arg tb		Index array to be filled (maxtype+1 elements).
+ * @arg maxtype		Maximum attribute type expected and accepted.
+ * @arg head		Head of attribute stream.
+ * @arg len		Length of attribute stream.
+ * @arg policy		Attribute validation policy.
+ *
+ * Iterates over the stream of attributes and stores a pointer to each
+ * attribute in the index array using the attribute type as index to
+ * the array. Attribute with a type greater than the maximum type
+ * specified will be silently ignored in order to maintain backwards
+ * compatibility. If \a policy is not NULL, the attribute will be
+ * validated using the specified policy.
+ *
+ * @see nla_validate
+ * @return 0 on success or a negative error code.
+ */
+int libbpf_nla_parse(struct nlattr *tb[], int maxtype, struct nlattr *head,
+		     int len, struct libbpf_nla_policy *policy)
+{
+	struct nlattr *nla;
+	int rem, err;
+
+	memset(tb, 0, sizeof(struct nlattr *) * (maxtype + 1));
+
+	libbpf_nla_for_each_attr(nla, head, len, rem) {
+		int type = nla_type(nla);
+
+		if (type > maxtype)
+			continue;
+
+		if (policy) {
+			err = validate_nla(nla, maxtype, policy);
+			if (err < 0)
+				goto errout;
+		}
+
+		if (tb[type])
+			fprintf(stderr, "Attribute of type %#x found multiple times in message, "
+				  "previous attribute is being ignored.\n", type);
+
+		tb[type] = nla;
+	}
+
+	err = 0;
+errout:
+	return err;
+}
+
+/**
+ * Create attribute index based on nested attribute
+ * @arg tb              Index array to be filled (maxtype+1 elements).
+ * @arg maxtype         Maximum attribute type expected and accepted.
+ * @arg nla             Nested Attribute.
+ * @arg policy          Attribute validation policy.
+ *
+ * Feeds the stream of attributes nested into the specified attribute
+ * to libbpf_nla_parse().
+ *
+ * @see libbpf_nla_parse
+ * @return 0 on success or a negative error code.
+ */
+int libbpf_nla_parse_nested(struct nlattr *tb[], int maxtype,
+			    struct nlattr *nla,
+			    struct libbpf_nla_policy *policy)
+{
+	return libbpf_nla_parse(tb, maxtype, libbpf_nla_data(nla),
+				libbpf_nla_len(nla), policy);
+}
+
+/* dump netlink extended ack error message */
+int libbpf_nla_dump_errormsg(struct nlmsghdr *nlh)
+{
+	struct libbpf_nla_policy extack_policy[NLMSGERR_ATTR_MAX + 1] = {
+		[NLMSGERR_ATTR_MSG]	= { .type = LIBBPF_NLA_STRING },
+		[NLMSGERR_ATTR_OFFS]	= { .type = LIBBPF_NLA_U32 },
+	};
+	struct nlattr *tb[NLMSGERR_ATTR_MAX + 1], *attr;
+	struct nlmsgerr *err;
+	char *errmsg = NULL;
+	int hlen, alen;
+
+	/* no TLVs, nothing to do here */
+	if (!(nlh->nlmsg_flags & NLM_F_ACK_TLVS))
+		return 0;
+
+	err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+	hlen = sizeof(*err);
+
+	/* if NLM_F_CAPPED is set then the inner err msg was capped */
+	if (!(nlh->nlmsg_flags & NLM_F_CAPPED))
+		hlen += nlmsg_len(&err->msg);
+
+	attr = (struct nlattr *) ((void *) err + hlen);
+	alen = nlh->nlmsg_len - hlen;
+
+	if (libbpf_nla_parse(tb, NLMSGERR_ATTR_MAX, attr, alen,
+			     extack_policy) != 0) {
+		fprintf(stderr,
+			"Failed to parse extended error attributes\n");
+		return 0;
+	}
+
+	if (tb[NLMSGERR_ATTR_MSG])
+		errmsg = (char *) libbpf_nla_data(tb[NLMSGERR_ATTR_MSG]);
+
+	fprintf(stderr, "Kernel error message: %s\n", errmsg);
+
+	return 0;
+}
+

--- a/elf/module.go
+++ b/elf/module.go
@@ -37,10 +37,22 @@ import (
 #include <strings.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include "include/bpf.h"
+#include "include/libbpf.h"
 #include <linux/perf_event.h>
 #include <linux/unistd.h>
 #include <sys/socket.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <errno.h>
+#include <net/if.h>
+#include <string.h>
+#include <linux/if_link.h>
+#include <linux/rtnetlink.h>
+
+#include "lib/nlattr.c"
+#include "lib/netlink.c"
 
 static int perf_event_open_tracepoint(int tracepoint_id, int pid, int cpu,
                            int group_fd, unsigned long flags)
@@ -89,6 +101,26 @@ int bpf_detach_socket(int sock, int fd)
 {
 	return setsockopt(sock, SOL_SOCKET, SO_DETACH_BPF, &fd, sizeof(fd));
 }
+
+int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags)
+{
+  	int ifindex = if_nametoindex(dev_name);
+  	char err_buf[256];
+  	int ret = -1;
+
+  	if (ifindex == 0) {
+    		fprintf(stderr, "bpf: Resolving device name to index: %s\n", strerror(errno));
+    		return -1;
+  	}
+
+  	ret = bpf_set_link_xdp_fd(ifindex, progfd, flags);
+  	if (ret) {
+    		fprintf(stderr, "bpf: Attaching prog to %s: %s", dev_name, err_buf);
+    		return -1;
+  	}
+
+  	return 0;
+}
 */
 import "C"
 
@@ -105,6 +137,7 @@ type Module struct {
 	socketFilters      map[string]*SocketFilter
 	tracepointPrograms map[string]*TracepointProgram
 	schedPrograms      map[string]*SchedProgram
+	xdpPrograms        map[string]*XDPProgram
 
 	compatProbe bool // try to be automatically convert function names depending on kernel versions (SyS_ and __x64_sys_)
 }
@@ -162,6 +195,13 @@ type SchedProgram struct {
 	fd    int
 }
 
+// XDPProgram represents a XDP hook program
+type XDPProgram struct {
+	Name  string
+	insns *C.struct_bpf_insn
+	fd    int
+}
+
 func newModule() *Module {
 	return &Module{
 		probes:             make(map[string]*Kprobe),
@@ -170,6 +210,7 @@ func newModule() *Module {
 		socketFilters:      make(map[string]*SocketFilter),
 		tracepointPrograms: make(map[string]*TracepointProgram),
 		schedPrograms:      make(map[string]*SchedProgram),
+		xdpPrograms:        make(map[string]*XDPProgram),
 		log:                make([]byte, 524288),
 	}
 }
@@ -413,6 +454,17 @@ func (b *Module) IterTracepointProgram() <-chan *TracepointProgram {
 	return ch
 }
 
+func (b *Module) IterXDPProgram() <-chan *XDPProgram {
+	ch := make(chan *XDPProgram)
+	go func() {
+		for name := range b.xdpPrograms {
+			ch <- b.xdpPrograms[name]
+		}
+		close(ch)
+	}()
+	return ch
+}
+
 func (b *Module) CgroupProgram(name string) *CgroupProgram {
 	return b.cgroupPrograms[name]
 }
@@ -440,7 +492,7 @@ func AttachUprobe(uprobe *Uprobe, path string, offset uint64) error {
 		probeType, safeEventName(path), offset, os.Getpid())
 
 	if _, ok := uprobe.efds[eventName]; ok {
-		return fmt.Errorf("uprobe already attached")
+		return errors.New("uprobe already attached")
 	}
 
 	uprobeID, err := writeUprobeEvent(probeType, eventName, path, offset)
@@ -456,6 +508,42 @@ func AttachUprobe(uprobe *Uprobe, path string, offset uint64) error {
 	uprobe.efds[eventName] = efd
 
 	return nil
+}
+
+func (b *Module) AttachXDP(devName string, secName string) error {
+	xdp, ok := b.xdpPrograms[secName]
+	if !ok {
+		return fmt.Errorf("no such XDP hook %q", secName)
+	}
+	if err := attachXDP(devName, xdp.fd, 0, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Module) RemoveXDP(devName string) error {
+	if err := attachXDP(devName, -1, 0, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+func attachXDP(devName string, fd int, flags uint32, attach bool) error {
+	devNameCS := C.CString(devName)
+	res, err := C.bpf_attach_xdp(devNameCS, C.int(fd), C.uint32_t(flags))
+	defer C.free(unsafe.Pointer(devNameCS))
+
+	if res != 0 || err != nil {
+		return fmt.Errorf(xdpFormat(attach), devName, err)
+	}
+	return nil
+}
+
+func xdpFormat(attach bool) string {
+	if attach {
+		return "failed to attach BPF xdp to device %s: %v"
+	}
+	return "failed to remove BPF xdp from device %s: %v"
 }
 
 func AttachCgroupProgram(cgroupProg *CgroupProgram, cgroupPath string, attachType AttachType) error {
@@ -604,6 +692,14 @@ func (sp *SchedProgram) Fd() int {
 	return sp.fd
 }
 
+func (b *Module) XDPProgram(name string) *XDPProgram {
+	return b.xdpPrograms[name]
+}
+
+func (xdpp *XDPProgram) Fd() int {
+	return xdpp.fd
+}
+
 func (b *Module) closeProbes() error {
 	var funcName string
 	for _, probe := range b.probes {
@@ -684,6 +780,15 @@ func (b *Module) closeSocketFilters() error {
 	return nil
 }
 
+func (b *Module) closeXDPPrograms() error {
+	for _, xdp := range b.xdpPrograms {
+		if err := syscall.Close(xdp.fd); err != nil {
+			return fmt.Errorf("error closing XDP program fd: %v", err)
+		}
+	}
+	return nil
+}
+
 func unpinMap(m *Map, pinPath string) error {
 	mapPath, err := getMapPath(&m.m.def, m.Name, pinPath)
 	if err != nil {
@@ -741,6 +846,7 @@ type CloseOptions struct {
 // * Detaching BPF programs from kprobes and closing their file descriptors
 // * Closing cgroup-bpf file descriptors
 // * Closing socket filter file descriptors
+// * Closing XDP file descriptors
 //
 // It doesn't detach BPF programs from cgroups or sockets because they're
 // considered resources the user controls.
@@ -767,6 +873,9 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 		return err
 	}
 	if err := b.closeSocketFilters(); err != nil {
+		return err
+	}
+	if err := b.closeXDPPrograms(); err != nil {
 		return err
 	}
 	return nil

--- a/tests/dummy.c
+++ b/tests/dummy.c
@@ -133,4 +133,14 @@ int socket__dummy(struct __sk_buff *skb)
 	return 0;
 }
 
+SEC("xdp/prog1")
+int xdp_drop(struct xdp_md *ctx) {
+    return XDP_DROP;
+}
+
+SEC("xdp/prog2")
+int xdp_pass(struct xdp_md *ctx) {
+    return XDP_PASS;
+}
+
 unsigned int _version SEC("version") = 0xFFFFFFFE;


### PR DESCRIPTION
This PR brings the support for XDP programs in ELF object files through `SEC(xdp/...)` annotations.
It allows for definition of multiple XDP programs in the same C source file. Once ELF module is instantiated/loaded, you can call `AttachXDP` passing the network device and the name of the XDP program you would like to attach on the interface. The XDP programs can be unloaded from the network device via `RemoveXDP` method.