### PR TITLE
fix: Debian version regex can fail on some debian versions if the commit sha is appended to the version

### DIFF
--- a/elf/kernel_version_test.go
+++ b/elf/kernel_version_test.go
@@ -52,3 +52,30 @@ func TestKernelVersionFromReleaseString(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDebianVersion(t *testing.T) {
+	for _, tc := range []struct {
+		succeed       bool
+		releaseString string
+		kernelVersion uint32
+	}{
+		// 4.9.168
+		{true, "Linux version 4.9.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.168-1+deb9u3 (2019-06-16)", 264616},
+		// 4.9.88
+		{true, "Linux ip-10-0-75-49 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux", 264536},
+		// 3.0.4
+		{true, "Linux version 3.16.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u2) ) #1 SMP Debian 3.16.68-1 (2019-05-22)", 200772},
+		// Invalid
+		{false, "Linux version 4.9.125-linuxkit (root@659b6d51c354) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Sep 7 08:20:28 UTC 2018", 0},
+	} {
+		version, err := parseDebianVersion(tc.releaseString)
+		if err != nil && tc.succeed {
+			t.Errorf("expected %q to succeed: %s", tc.releaseString, err)
+		} else if err == nil && !tc.succeed {
+			t.Errorf("expected %q to fail", tc.releaseString)
+		}
+		if version != tc.kernelVersion {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}


### PR DESCRIPTION
This fixes the parsing of the `/proc/version` file for some debian versions.

This was causing `bpf_prog_load` to fail on [this check](https://elixir.bootlin.com/linux/v4.4/source/kernel/bpf/syscall.c#L630).

The fix is to add an optional group after the kernel version to match a commit hash (multiple alphanumeric characters).
