### PR TITLE
add missing call to unmap and disable when freeing a perf ring buffer

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -882,6 +882,7 @@ func (b *Module) initializePerfMaps(parameters map[string]SectionParams) error {
 
 			b.maps[name].pmuFDs = append(b.maps[name].pmuFDs, pmuFD)
 			b.maps[name].headers = append(b.maps[name].headers, (*C.struct_perf_event_mmap_page)(unsafe.Pointer(&base[0])))
+			b.maps[name].bases = append(b.maps[name].bases, base)
 		}
 	}
 
@@ -920,6 +921,7 @@ type Map struct {
 	// only for perf maps
 	pmuFDs    []C.int
 	headers   []*C.struct_perf_event_mmap_page
+	bases     [][]byte
 	pageCount int
 }
 


### PR DESCRIPTION
Before closing the file descriptors of the perf ring buffer it is needed to
unmap and disable them.

https://github.com/iovisor/bcc/blob/d147588ebe35b7cd2b4d253a7da18bef253ea78d/src/cc/perf_reader.c#L69