### PR TITLE
Fix bpf_attr initialization

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -125,7 +125,8 @@ void create_bpf_obj_get(const char *pathname, void *attr)
 
 int get_pinned_obj_fd(const char *path)
 {
-	union bpf_attr attr = {};
+	union bpf_attr attr;
+	memset(&attr, 0, sizeof(attr));
 	create_bpf_obj_get(path, &attr);
 	return syscall(__NR_bpf, BPF_OBJ_GET, &attr, sizeof(attr));
 }
@@ -231,12 +232,13 @@ static int bpf_prog_load(enum bpf_prog_type prog_type,
 
 static int bpf_update_element(int fd, void *key, void *value, unsigned long long flags)
 {
-	union bpf_attr attr = {
-		.map_fd = fd,
-		.key = ptr_to_u64(key),
-		.value = ptr_to_u64(value),
-		.flags = flags,
-	};
+	union bpf_attr attr;
+
+	memset(&attr, 0, sizeof(attr));
+	attr.map_fd = fd;
+	attr.key = ptr_to_u64(key);
+	attr.value = ptr_to_u64(value);
+	attr.flags = flags;
 
 	return syscall(__NR_bpf, BPF_MAP_UPDATE_ELEM, &attr, sizeof(attr));
 }

--- a/elf/module.go
+++ b/elf/module.go
@@ -59,7 +59,7 @@ int bpf_prog_attach(int prog_fd, int target_fd, enum bpf_attach_type type)
 {
 	union bpf_attr attr;
 
-	bzero(&attr, sizeof(attr));
+	memset(&attr, 0, sizeof(attr));
 	attr.target_fd	   = target_fd;
 	attr.attach_bpf_fd = prog_fd;
 	attr.attach_type   = type;
@@ -71,7 +71,7 @@ int bpf_prog_detach(int prog_fd, int target_fd, enum bpf_attach_type type)
 {
 	union bpf_attr attr;
 
-	bzero(&attr, sizeof(attr));
+	memset(&attr, 0, sizeof(attr));
 	attr.target_fd	   = target_fd;
 	attr.attach_bpf_fd = prog_fd;
 	attr.attach_type   = type;

--- a/elf/pinning.go
+++ b/elf/pinning.go
@@ -16,14 +16,16 @@ import (
 #include <linux/unistd.h>
 #include <linux/bpf.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 extern __u64 ptr_to_u64(void *);
 
 int bpf_pin_object(int fd, const char *pathname)
 {
-	union bpf_attr attr = {};
+	union bpf_attr attr;
 
+	memset(&attr, 0, sizeof(attr));
 	attr.pathname = ptr_to_u64((void *)pathname);
 	attr.bpf_fd = fd;
 

--- a/pkg/progtestrun/prog_test_run.go
+++ b/pkg/progtestrun/prog_test_run.go
@@ -23,7 +23,7 @@ int bpf_prog_test_run(int fd, int repeat, char *data, int data_size,
 		      int *duration)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	union bpf_attr attr = {};
+	union bpf_attr attr;
 	int ret;
 
 	memset(&attr, 0, sizeof(attr));


### PR DESCRIPTION
Using plain initialization list for a union with nested anonymous
structs works incorrectly with Clang.  `syscall()` in `bpf_update_element()`
may fail if `bpf_attr` is improperly initialized.  Initialization with
`memset()` is more portable.