### PR TITLE
elf: include gobpf's bpf.h instead of host's

### DIFF
--- a/elf/table.go
+++ b/elf/table.go
@@ -25,7 +25,7 @@ import (
 )
 
 /*
-#include <linux/bpf.h>
+#include "include/bpf.h"
 #include <linux/unistd.h>
 
 extern __u64 ptr_to_u64(void *);


### PR DESCRIPTION
To enable build on old build servers with an outdated `/usr/include/linux/bpf.h`, use gobpf's copy instead.