### PR TITLE
string.h inclusion needed in module.log for memset

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -35,6 +35,7 @@ import (
 /*
 #include <unistd.h>
 #include <strings.h>
+#include <string.h>
 #include <stdlib.h>
 #include "include/bpf.h"
 #include <linux/perf_event.h>


### PR DESCRIPTION
Current error when running a go binary using this lib:
```
warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
  memset(&attr, 0, sizeof(attr));
  ^~~~~~
```

PR #207 fixed/improved the `union bpf_attr` initialization using `memset`, but forgot to include `string.h` in elf/module.go (while in elf/elf.go there already was, and in elf/pinning.go was added)

Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>