### PR TITLE
semaphore: update to new gobpf-ci image (bcc v0.11.0)

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -38,7 +38,7 @@ for kernel_version in "${kernel_versions[@]}"; do
     --dns=8.8.8.8 \
     --stage1-name="kinvolk.io/aci/rkt/stage1-kvm:${rkt_version},kernelversion=${kernel_version}" \
     --volume=gobpf,kind=host,source="$PWD" \
-    docker://schu/gobpf-ci:1f3a531e145a9f5f8bd53e55908d21240491202c \
+    docker://schu/gobpf-ci:d39b30bc8f1787ade80a2f5bac6ec0afbbc392b1 \
     --memory=1024M \
     --mount=volume=gobpf,target=/go/src/github.com/iovisor/gobpf \
     --environment=GOPATH=/go \


### PR DESCRIPTION
Looking into a fix for our CI setup separately.