### PR TITLE
Add btf loading support for programs

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -227,7 +227,7 @@ func (bpf *Module) load(name string, progType int, logLevel, logSize uint) (int,
 		logBuf = make([]byte, logSize)
 		logBufP = (*C.char)(unsafe.Pointer(&logBuf[0]))
 	}
-	fd, err := C.bcc_func_load(bpf.p, C.int(uint32(progType)), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)))
+	fd, err := C.bcc_func_load(bpf.p, C.int(uint32(progType)), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)), nil)
 	if fd < 0 {
 		return -1, fmt.Errorf("error loading BPF program: %v", err)
 	}

--- a/bcc/module.go
+++ b/bcc/module.go
@@ -227,7 +227,7 @@ func (bpf *Module) load(name string, progType int, logLevel, logSize uint) (int,
 		logBuf = make([]byte, logSize)
 		logBufP = (*C.char)(unsafe.Pointer(&logBuf[0]))
 	}
-	fd, err := C.bcc_prog_load(uint32(progType), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)))
+	fd, err := C.bcc_func_load(bpf.p, C.int(uint32(progType)), nameCS, start, size, license, version, C.int(logLevel), logBufP, C.uint(len(logBuf)))
 	if fd < 0 {
 		return -1, fmt.Errorf("error loading BPF program: %v", err)
 	}


### PR DESCRIPTION
This applies changes from the following commit in BCC 0.9.0:

* https://github.com/iovisor/bcc/commit/48ca7819c4be5f236b7936d5af9a3cab287cb41b

It requires a newer LLVM to produce BTF (I use 9.0), but also supports older
versions where it works without producing BTF just like before.

Consider the following code:

```c
struct key {
  u32 prog_id;
  u32 act;
};

// Max. number of XDP programs we expect concurrently
const u8 max_progs = 10;

// Number of valid actions
const int num_actions = XDP_REDIRECT+1;

// Use small LRU hash to avoid losing observations
BPF_F_TABLE("lru_hash", struct key, u64, exceptions, max_progs * num_actions, 0);

// Generates function tracepoint__xdp__xdp_exception
TRACEPOINT_PROBE(xdp, xdp_exception) {
  struct key key = {
    .prog_id = args->prog_id,
    .act = args->act,
  };

  u64 *val = exceptions.lookup(&key);
  if (!val) {
    u64 one = 1;
    // This may fail, but there is no useful action
    // we can take in that case.
    exceptions.insert(&key, &one);
  } else {
    // Not atomic, but that's not a deal breaker.
    *val += 1;
  }
  return 0;
}
```

Without this change we cannot see any annotations in xlated code:

```
$ sudo bpftool prog dump xlated id 1849
   0: (61) r2 = *(u32 *)(r1 +8)
   1: (63) *(u32 *)(r10 -8) = r2
   2: (61) r1 = *(u32 *)(r1 +12)
   3: (63) *(u32 *)(r10 -4) = r1
   4: (18) r1 = map[id:4555]
   6: (bf) r2 = r10
   7: (07) r2 += -8
   8: (85) call __htab_map_lookup_elem#100208
   9: (15) if r0 == 0x0 goto pc+4
  10: (71) r1 = *(u8 *)(r0 +35)
  11: (55) if r1 != 0x0 goto pc+1
  12: (72) *(u8 *)(r0 +35) = 1
  13: (07) r0 += 56
  14: (55) if r0 != 0x0 goto pc+11
  15: (b7) r1 = 1
  16: (7b) *(u64 *)(r10 -16) = r1
  17: (18) r1 = map[id:4555]
  19: (bf) r2 = r10
  20: (07) r2 += -8
  21: (bf) r3 = r10
  22: (07) r3 += -16
  23: (b7) r4 = 1
  24: (85) call htab_lru_map_update_elem#104272
  25: (05) goto pc+3
  26: (79) r1 = *(u64 *)(r0 +0)
  27: (07) r1 += 1
  28: (7b) *(u64 *)(r0 +0) = r1
  29: (b7) r0 = 0
  30: (95) exit
```

With this change we can:

```
$ sudo bpftool prog dump xlated id 2384
int tracepoint__xdp__xdp_exception(struct tracepoint__xdp__xdp_exception * args):
; .prog_id = args->prog_id,
   0: (61) r2 = *(u32 *)(r1 +8)
; struct key key = {
   1: (63) *(u32 *)(r10 -8) = r2
; .act = args->act,
   2: (61) r1 = *(u32 *)(r1 +12)
; struct key key = {
   3: (63) *(u32 *)(r10 -4) = r1
; u64 *val = bpf_map_lookup_elem((void *)bpf_pseudo_fd(1, -1), &key);
   4: (18) r1 = map[id:7585]
   6: (bf) r2 = r10
;
   7: (07) r2 += -8
; u64 *val = bpf_map_lookup_elem((void *)bpf_pseudo_fd(1, -1), &key);
   8: (85) call __htab_map_lookup_elem#100208
   9: (15) if r0 == 0x0 goto pc+4
  10: (71) r1 = *(u8 *)(r0 +35)
  11: (55) if r1 != 0x0 goto pc+1
  12: (72) *(u8 *)(r0 +35) = 1
  13: (07) r0 += 56
; if (!val) {
  14: (55) if r0 != 0x0 goto pc+11
  15: (b7) r1 = 1
; u64 one = 1;
  16: (7b) *(u64 *)(r10 -16) = r1
; bpf_map_update_elem((void *)bpf_pseudo_fd(1, -1), &key, &one, BPF_NOEXIST);
  17: (18) r1 = map[id:7585]
  19: (bf) r2 = r10
;
  20: (07) r2 += -8
  21: (bf) r3 = r10
  22: (07) r3 += -16
; bpf_map_update_elem((void *)bpf_pseudo_fd(1, -1), &key, &one, BPF_NOEXIST);
  23: (b7) r4 = 1
  24: (85) call htab_lru_map_update_elem#104272
  25: (05) goto pc+3
; *val += 1;
  26: (79) r1 = *(u64 *)(r0 +0)
  27: (07) r1 += 1
  28: (7b) *(u64 *)(r0 +0) = r1
; return 0;
  29: (b7) r0 = 0
  30: (95) exit
```

Same goes for jited:

```
$ sudo bpftool prog dump jited id 2384
int tracepoint__xdp__xdp_exception(struct tracepoint__xdp__xdp_exception * args):
0xffffffffc01e84c4:
; .prog_id = args->prog_id,
   0:	push   %rbp
   1:	mov    %rsp,%rbp
   4:	sub    $0x10,%rsp
   b:	push   %rbx
   c:	push   %r13
   e:	push   %r14
  10:	push   %r15
  12:	pushq  $0x0
  14:	mov    0x8(%rdi),%esi
; struct key key = {
  17:	mov    %esi,-0x8(%rbp)
; .act = args->act,
  1a:	mov    0xc(%rdi),%edi
; struct key key = {
  1d:	mov    %edi,-0x4(%rbp)
; u64 *val = bpf_map_lookup_elem((void *)bpf_pseudo_fd(1, -1), &key);
  20:	movabs $0xffff8c4361f44800,%rdi
  2a:	mov    %rbp,%rsi
;
  2d:	add    $0xfffffffffffffff8,%rsi
; u64 *val = bpf_map_lookup_elem((void *)bpf_pseudo_fd(1, -1), &key);
  31:	callq  0xffffffffcb98f8dc
  36:	cmp    $0x0,%rax
  3a:	je     0x000000000000004f
  3c:	movzbq 0x23(%rax),%rdi
  41:	cmp    $0x0,%rdi
  45:	jne    0x000000000000004b
  47:	movb   $0x1,0x23(%rax)
  4b:	add    $0x38,%rax
; if (!val) {
  4f:	cmp    $0x0,%rax
  53:	jne    0x0000000000000082
  55:	mov    $0x1,%edi
; u64 one = 1;
  5a:	mov    %rdi,-0x10(%rbp)
; bpf_map_update_elem((void *)bpf_pseudo_fd(1, -1), &key, &one, BPF_NOEXIST);
  5e:	movabs $0xffff8c4361f44800,%rdi
  68:	mov    %rbp,%rsi
;
  6b:	add    $0xfffffffffffffff8,%rsi
  6f:	mov    %rbp,%rdx
  72:	add    $0xfffffffffffffff0,%rdx
; bpf_map_update_elem((void *)bpf_pseudo_fd(1, -1), &key, &one, BPF_NOEXIST);
  76:	mov    $0x1,%ecx
  7b:	callq  0xffffffffcb9908bc
  80:	jmp    0x000000000000008e
; *val += 1;
  82:	mov    0x0(%rax),%rdi
  86:	add    $0x1,%rdi
  8a:	mov    %rdi,0x0(%rax)
; return 0;
  8e:	xor    %eax,%eax
  90:	pop    %rbx
  91:	pop    %r15
  93:	pop    %r14
  95:	pop    %r13
  97:	pop    %rbx
  98:	leaveq
  99:	retq
```