### PR TITLE
elf: export NowNanoseconds

### DIFF
--- a/elf/perf.go
+++ b/elf/perf.go
@@ -190,7 +190,7 @@ func (pm *PerfMap) PollStart() {
 				}
 
 				var harvestCount C.int
-				beforeHarvest := nowNanoseconds()
+				beforeHarvest := NowNanoseconds()
 				for cpu := 0; cpu < cpuCount; cpu++ {
 				ringBufferLoop:
 					for {
@@ -314,8 +314,8 @@ type PerfEventLost struct {
 	Lost uint64
 }
 
-// nowNanoseconds returns a time that can be compared to bpf_ktime_get_ns()
-func nowNanoseconds() uint64 {
+// NowNanoseconds returns a time that can be compared to bpf_ktime_get_ns()
+func NowNanoseconds() uint64 {
 	var ts syscall.Timespec
 	syscall.Syscall(syscall.SYS_CLOCK_GETTIME, 1 /* CLOCK_MONOTONIC */, uintptr(unsafe.Pointer(&ts)), 0)
 	sec, nsec := ts.Unix()

--- a/elf/perf_unsupported.go
+++ b/elf/perf_unsupported.go
@@ -13,3 +13,7 @@ func (pm *PerfMap) SetTimestampFunc(timestamp func(*[]byte) uint64) {}
 func (pm *PerfMap) PollStart() {}
 
 func (pm *PerfMap) PollStop() {}
+
+func NowNanoseconds() uint64 {
+	return 0
+}


### PR DESCRIPTION
NowNanoseconds() is a useful helper func in apps that track, e.g.,
time delta to a time stamp set (using bpf_ktime_get_ns()) by eBPF.

Fixes: #213