### PR TITLE
elf - remove extraneous whitespace from debianVersionRegex

### DIFF
--- a/elf/kernel_version.go
+++ b/elf/kernel_version.go
@@ -75,7 +75,7 @@ func currentVersionUbuntu() (uint32, error) {
 	return KernelVersionFromReleaseString(releaseString)
 }
 
-var debianVersionRegex = regexp.MustCompile(`.* SMP Debian (\d+\.\d+.\d+-\d+) .*`)
+var debianVersionRegex = regexp.MustCompile(`.* SMP Debian (\d+\.\d+.\d+-\d+).*`)
 
 func currentVersionDebian() (uint32, error) {
 	procVersion, err := ioutil.ReadFile("/proc/version")


### PR DESCRIPTION
Here are two examples of Stretch and Buster version strings, respectively: https://regexr.com/4q232.
The regex does not match a segment like `SMP Debian 4.19.37-5+deb10u2`.

Is this worth refactoring so it can be unit tested?