### PR TITLE
elf: fix cgo include paths

### DIFF
--- a/elf/lib/netlink.c
+++ b/elf/lib/netlink.c
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <time.h>
 
-#include "include/bpf.h"
-#include "include/libbpf.h"
-#include "include/nlattr.h"
+#include "bpf.h"
+#include "libbpf.h"
+#include "nlattr.h"
 
 #ifndef SOL_NETLINK
 #define SOL_NETLINK 270

--- a/elf/lib/nlattr.c
+++ b/elf/lib/nlattr.c
@@ -7,7 +7,7 @@
  */
 
 #include <errno.h>
-#include "include/nlattr.h"
+#include "nlattr.h"
 #include <linux/rtnetlink.h>
 #include <string.h>
 #include <stdio.h>

--- a/elf/module.go
+++ b/elf/module.go
@@ -38,8 +38,8 @@ import (
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include "include/bpf.h"
-#include "include/libbpf.h"
+#include "bpf.h"
+#include "libbpf.h"
 #include <linux/perf_event.h>
 #include <linux/unistd.h>
 #include <sys/socket.h>
@@ -122,6 +122,7 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags)
   	return 0;
 }
 */
+// #cgo CFLAGS: -I${SRCDIR}/include
 import "C"
 
 type Module struct {


### PR DESCRIPTION
On some systems the cgo processing fails with missing headers:

lib/nlattr.c:10:10: fatal error: include/nlattr.h: No such file or directory
10 | #include "include/nlattr.h"
   |          ^~~~~~~~~~~~~~~~~~
compilation terminated.

This commit adds the header path to cgo CFLAGS that then gets passed
to gcc.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>