### PR TITLE
fix module_create_string compiler error

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -95,7 +95,7 @@ func newModule(code string, cflags []string) *Module {
 	}
 	cs := C.CString(code)
 	defer C.free(unsafe.Pointer(cs))
-	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)), (C.bool)(true), nil)
+	c := C.bpf_module_create_c_from_string(cs, c.uint(2), (**C.char)(&cflagsC[0]), C.int(len(cflagsC)), (C.bool)(true))
 	if c == nil {
 		return nil
 	}


### PR DESCRIPTION
I'm not entirely sure if this is related to any specific part of my toolchain but when trying to use the module I ran into this error

```
../../go/pkg/mod/github.com/sauercrowd/gobpf@v0.0.0-20191219090757-e72091e3c5e6/bcc/module.go:98:40: too many arguments in call to _Cfunc_bpf_module_create_c_from_string
	have (*_Ctype_char, number, **_Ctype_char, _Ctype_int, _Ctype__Bool, nil)
	want (*_Ctype_char, _Ctype_uint, **_Ctype_char, _Ctype_int, _Ctype__Bool)
```