### PR TITLE
add lost events channel

### DIFF
--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -30,9 +30,11 @@ import (
 #include <bcc/libbpf.h>
 #include <bcc/perf_reader.h>
 
-// perf_reader_raw_cb as defined in bcc libbpf.h
+// perf_reader_raw_cb and perf_reader_lost_cb as defined in bcc libbpf.h
 // typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
-extern void callback_to_go(void*, void*, int);
+extern void rawCallback(void*, void*, int);
+// typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
+extern void lostCallback(void*, uint64_t);
 */
 import "C"
 
@@ -44,6 +46,7 @@ type PerfMap struct {
 
 type callbackData struct {
 	receiverChan chan []byte
+	lostChan     chan uint64
 }
 
 // BPF_PERF_READER_PAGE_CNT is the default page_cnt used per cpu ring buffer
@@ -85,10 +88,18 @@ func lookupCallback(i uint64) *callbackData {
 // be written. This is because we can't take the address of a Go
 // function and give that to C-code since the cgo tool will generate a
 // stub in C that should be called."
-//export callback_to_go
-func callback_to_go(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) {
+//export rawCallback
+func rawCallback(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) {
 	callbackData := lookupCallback(uint64(uintptr(cbCookie)))
 	callbackData.receiverChan <- C.GoBytes(raw, rawSize)
+}
+
+//export lostCallback
+func lostCallback(cbCookie unsafe.Pointer, lost C.ulong) {
+	callbackData := lookupCallback(uint64(uintptr(cbCookie)))
+	if callbackData.lostChan != nil {
+		callbackData.lostChan <- uint64(lost)
+	}
 }
 
 // GetHostByteOrder returns the current byte-order.
@@ -109,12 +120,12 @@ func determineHostByteOrder() binary.ByteOrder {
 }
 
 // InitPerfMap initializes a perf map with a receiver channel, with a default page_cnt.
-func InitPerfMap(table *Table, receiverChan chan []byte) (*PerfMap, error) {
-	return InitPerfMapWithPageCnt(table, receiverChan, BPF_PERF_READER_PAGE_CNT)
+func InitPerfMap(table *Table, receiverChan chan []byte, lostChan chan uint64) (*PerfMap, error) {
+	return InitPerfMapWithPageCnt(table, receiverChan, lostChan, BPF_PERF_READER_PAGE_CNT)
 }
 
 // InitPerfMapWithPageCnt initializes a perf map with a receiver channel with a specified page_cnt.
-func InitPerfMapWithPageCnt(table *Table, receiverChan chan []byte, pageCnt int) (*PerfMap, error) {
+func InitPerfMapWithPageCnt(table *Table, receiverChan chan []byte, lostChan chan uint64, pageCnt int) (*PerfMap, error) {
 	fd := table.Config()["fd"].(int)
 	keySize := table.Config()["key_size"].(uint64)
 	leafSize := table.Config()["leaf_size"].(uint64)
@@ -125,6 +136,7 @@ func InitPerfMapWithPageCnt(table *Table, receiverChan chan []byte, pageCnt int)
 
 	callbackDataIndex := registerCallback(&callbackData{
 		receiverChan,
+		lostChan,
 	})
 
 	key := make([]byte, keySize)
@@ -199,8 +211,8 @@ func bpfOpenPerfBuffer(cpu uint, callbackDataIndex uint64, pageCnt int) (unsafe.
 	cpuC := C.int(cpu)
 	pageCntC := C.int(pageCnt)
 	reader, err := C.bpf_open_perf_buffer(
-		(C.perf_reader_raw_cb)(unsafe.Pointer(C.callback_to_go)),
-		nil,
+		(C.perf_reader_raw_cb)(unsafe.Pointer(C.rawCallback)),
+		(C.perf_reader_lost_cb)(unsafe.Pointer(C.lostCallback)),
 		unsafe.Pointer(uintptr(callbackDataIndex)),
 		-1, cpuC, pageCntC)
 	if reader == nil {

--- a/elf/perf_unsupported.go
+++ b/elf/perf_unsupported.go
@@ -4,7 +4,7 @@ package elf
 
 type PerfMap struct{}
 
-func InitPerfMap(b *Module, mapName string, receiverChan chan []byte) (*PerfMap, error) {
+func InitPerfMap(b *Module, mapName string, receiverChan chan []byte, lostChan chan uint64) (*PerfMap, error) {
 	return nil, errNotSupported
 }
 

--- a/examples/bcc/bash_readline/bash_readline.go
+++ b/examples/bcc/bash_readline/bash_readline.go
@@ -73,7 +73,7 @@ func main() {
 
 	channel := make(chan []byte)
 
-	perfMap, err := bpf.InitPerfMap(table, channel)
+	perfMap, err := bpf.InitPerfMap(table, channel, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to init perf map: %s\n", err)
 		os.Exit(1)

--- a/examples/bcc/execsnoop/execsnoop.go
+++ b/examples/bcc/execsnoop/execsnoop.go
@@ -228,7 +228,7 @@ func run() {
 
 	channel := make(chan []byte, 1000)
 
-	perfMap, err := bpf.InitPerfMap(table, channel)
+	perfMap, err := bpf.InitPerfMap(table, channel, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to init perf map: %s\n", err)
 		os.Exit(1)

--- a/examples/bcc/perf/perf.go
+++ b/examples/bcc/perf/perf.go
@@ -118,7 +118,7 @@ func main() {
 
 	channel := make(chan []byte)
 
-	perfMap, err := bpf.InitPerfMap(table, channel)
+	perfMap, err := bpf.InitPerfMap(table, channel, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to init perf map: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
this PR adds support for handling lost events using a dedicated channel, similar to how regular events are handled.
a future PR can update the examples to utilize this feature. at the moment I just passed nil which does no change to existing functionality.