### PR TITLE
fix bpf_module_create_c_from_string with remove last arguments

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -95,7 +95,7 @@ func newModule(code string, cflags []string) *Module {
 	}
 	cs := C.CString(code)
 	defer C.free(unsafe.Pointer(cs))
-	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)), (C.bool)(true), nil)
+	c := C.bpf_module_create_c_from_string(cs, 2, (**C.char)(&cflagsC[0]), C.int(len(cflagsC)), (C.bool)(true))
 	if c == nil {
 		return nil
 	}


### PR DESCRIPTION
fix bpf_module_create_c_from_string with libbcc version 0.10.0-34.git.6836168. 