### PR TITLE
Add dummy Map.Fd() implementation

### DIFF
--- a/elf/elf_unsupported.go
+++ b/elf/elf_unsupported.go
@@ -29,3 +29,8 @@ func (b *BPFKProbePerf) PollStop(mapName string) {
 	// not supported
 	return
 }
+
+func (m *Map) Fd() int {
+        // not supported
+	return -1
+}


### PR DESCRIPTION
This allows avoiding syntax errors on non-Linux systems. Resolves #238.