### PR TITLE
fix memory leak in bccResolveName

### DIFF
--- a/bcc/symbol.go
+++ b/bcc/symbol.go
@@ -96,6 +96,7 @@ func bccResolveName(module, symname string, pid int) (uint64, error) {
 
 	pidC := C.int(pid)
 	cache := C.bcc_symcache_new(pidC, symbolC)
+	defer C.bcc_free_symcache(cache, pidC)
 
 	moduleCS := C.CString(module)
 	defer C.free(unsafe.Pointer(moduleCS))


### PR DESCRIPTION
This function calls `bcc_symcache_new` which creates an [internal instance of the cache](https://sourcegraph.com/github.com/iovisor/bcc@d2e8ea4/-/blob/src/cc/bcc_syms.cc#L520), but doesn't release it.