### PR TITLE
cache syscall prefix

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -523,16 +523,16 @@ func GetSyscallFnName(name string) string {
 	return GetSyscallPrefix() + name
 }
 
+var syscallPrefix string
+
 func GetSyscallPrefix() string {
-	_, err := bccResolveName("", "sys_bpf", -1)
-	if err == nil {
-		return "sys_"
+	if syscallPrefix == "" {
+		_, err := bccResolveName("", "__x64_sys_bpf", -1)
+		if err == nil {
+			syscallPrefix = "__x64_sys_"
+		} else {
+			syscallPrefix = "sys_"
+		}
 	}
-
-	_, err = bccResolveName("", "__x64_sys_bpf", -1)
-	if err == nil {
-		return "__x64_sys_"
-	}
-
-	return "sys_"
+	return syscallPrefix
 }


### PR DESCRIPTION
The syscall prefix cannot change on same system, so it's wasteful to re-calculate it.