### PR TITLE
elf: Fix closing tracepoint programs

### DIFF
--- a/elf/elf.go
+++ b/elf/elf.go
@@ -668,6 +668,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						Name:  secName,
 						insns: insns,
 						fd:    int(progFd),
+						efd:   -1,
 					}
 				case isSchedCls:
 					fallthrough
@@ -804,6 +805,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),
+					efd:   -1,
 				}
 			case isSchedCls:
 				fallthrough


### PR DESCRIPTION
The logic to close tracepoint programs was closing the STDIN file descriptor
because an initialization to -1 was missing.

Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>