### PR TITLE
add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/iovisor/gobpf
+
+go 1.14


### PR DESCRIPTION
PR adds a `go.mod` file to make it easier to build the project outside of `$GOPATH/src` tree.