### PR TITLE
elf: uprobe_events does not expect a newline at the end of event specification

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -282,7 +282,7 @@ func writeUprobeEvent(probeType, eventName, path string, offset uint64) (int, er
 	}
 	defer f.Close()
 
-	cmd := fmt.Sprintf("%s:%s %s:%#x\n", probeType, eventName, path, offset)
+	cmd := fmt.Sprintf("%s:%s %s:%#x", probeType, eventName, path, offset)
 
 	if _, err = f.WriteString(cmd); err != nil {
 		return -1, fmt.Errorf("cannot write %q to uprobe_events: %v", cmd, err)


### PR DESCRIPTION
This removes explicit newline when writing to /sys/kernel/debug/tracing/uprobe_events

See the following:
```
 # echo 'p:p_x /lib/libc-2.30.so:0x0\n' > uprobe_events
 -bash: echo: write error: Invalid argument
 # echo 'p:p_x /lib/libc-2.30.so:0x0' > uprobe_events
 # cat uprobe_events
 p:uprobes/p_x /lib/libc-2.30.so:0x0000000000000000
```