### PR TITLE
Use exact width integer argument to lostCallback. 

### DIFF
--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -95,7 +95,7 @@ func rawCallback(cbCookie unsafe.Pointer, raw unsafe.Pointer, rawSize C.int) {
 }
 
 //export lostCallback
-func lostCallback(cbCookie unsafe.Pointer, lost C.ulong) {
+func lostCallback(cbCookie unsafe.Pointer, lost C.uint64_t) {
 	callbackData := lookupCallback(uint64(uintptr(cbCookie)))
 	if callbackData.lostChan != nil {
 		callbackData.lostChan <- uint64(lost)


### PR DESCRIPTION
Fixes #272 

`lostCallback` is exported via CGO and re-imported elsewhere as a C function.
The second argument is declared as uint64_t when re-imported, but declared
as unsigned long in the original Go function definition.  These two types
are not the same size on all architectures, and cause build failures on
systems where the types mismatch.

This commit changes the original function definition of lostCallback to
use the type C.uint64_t instead of C.ulong for the second argument, to
maintain compatibility across architectures.