### PR TITLE
elf: add Module.RemoveXDPWithFlags method

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -556,6 +556,15 @@ func (b *Module) RemoveXDP(devName string) error {
 	return nil
 }
 
+// RemoveXDPWithFlags removes an xdp section from a device
+// using the provided flags.
+func (b *Module) RemoveXDPWithFlags(devName string, flags uint32) error {
+	if err := attachXDP(devName, -1, flags, false); err != nil {
+		return err
+	}
+	return nil
+}
+
 func attachXDP(devName string, fd int, flags uint32, attach bool) error {
 	devNameCS := C.CString(devName)
 	res, err := C.bpf_attach_xdp(devNameCS, C.int(fd), C.uint32_t(flags))


### PR DESCRIPTION
PR adds a method `Module.RemoveXDPWithFlags` to allow unloading xdp sections loaded with `SKB` aka `xdpgeneric` flags (mode). Currently `AttachXDP` has a "sibling" `AttachXDPWithFlags` but `RemoveXDP` doesn't.  I was playing with modifying https://github.com/sematext/oxdpus and had to resort to vendoring this repository to add `RemoveXDPWithFlags` function - only then I was able to unload the xdp program loaded with `XDP_FLAGS_SKB_MODE` [1].

[1] https://github.com/dmitris/oxdpus/blob/skb-mode-vendor/vendordeps/github.com/iovisor/gobpf/elf/module.go#L543-L550, used in https://github.com/dmitris/oxdpus/blob/skb-mode-vendor/pkg/xdp/hook.go#L80