### PR TITLE
`pkg/ksym` add feature: adds Kaddr(), which can look up an address from a kernel function name

### DIFF
--- a/pkg/ksym/ksym.go
+++ b/pkg/ksym/ksym.go
@@ -11,44 +11,76 @@ import (
 
 const (
 	KALLSYMS = "/proc/kallsyms"
+	ADDRCOL  = 0
+	SYMCOL   = 2
 )
 
-type ksymCache struct {
+type kCache struct {
 	sync.RWMutex
 	ksym map[string]string
 }
 
-var cache ksymCache
+var symCache kCache
+var addrCache kCache
 
 // Ksym translates a kernel memory address into a kernel function name
 // using `/proc/kallsyms`
 func Ksym(addr string) (string, error) {
-	if cache.ksym == nil {
-		cache.ksym = make(map[string]string)
+	if symCache.ksym == nil {
+		symCache.ksym = make(map[string]string)
 	}
 
-	cache.Lock()
-	defer cache.Unlock()
+	symCache.Lock()
+	defer symCache.Unlock()
 
-	if _, ok := cache.ksym[addr]; !ok {
+	if _, ok := symCache.ksym[addr]; !ok {
 		fd, err := os.Open(KALLSYMS)
 		if err != nil {
 			return "", err
 		}
 		defer fd.Close()
 
-		fn := ksym(addr, fd)
+		fn := kLookup(addr, fd, ADDRCOL, SYMCOL)
 		if fn == "" {
 			return "", errors.New("kernel function not found for " + addr)
 		}
 
-		cache.ksym[addr] = fn
+		symCache.ksym[addr] = fn
 	}
 
-	return cache.ksym[addr], nil
+	return symCache.ksym[addr], nil
 }
 
-func ksym(addr string, r io.Reader) string {
+// Kaddr translates a kernel function name into a memory address
+// using `/proc/kallsyms`
+func Kaddr(addr string) (string, error) {
+	if addrCache.ksym == nil {
+		addrCache.ksym = make(map[string]string)
+	}
+
+	addrCache.Lock()
+	defer addrCache.Unlock()
+
+	if _, ok := addrCache.ksym[addr]; !ok {
+		fd, err := os.Open(KALLSYMS)
+		if err != nil {
+			return "", err
+		}
+		defer fd.Close()
+
+		fn := kLookup(addr, fd, SYMCOL, ADDRCOL)
+		if fn == "" {
+			return "", errors.New("kernel function not found for " + addr)
+		}
+
+		addrCache.ksym[addr] = fn
+	}
+
+	return addrCache.ksym[addr], nil
+}
+
+// kLookup scans given file for string in keyColumn and returns value in valColumn
+func kLookup(addr string, r io.Reader, keyColumn int, valColumn int) string {
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		l := s.Text()
@@ -57,8 +89,8 @@ func ksym(addr string, r io.Reader) string {
 			continue
 		}
 
-		if ar[0] == addr {
-			return ar[2]
+		if ar[keyColumn] == addr {
+			return ar[valColumn]
 		}
 	}
 

--- a/pkg/ksym/ksym_test.go
+++ b/pkg/ksym/ksym_test.go
@@ -5,13 +5,28 @@ import (
 	"testing"
 )
 
+const (
+	data = "ffffffff91b2a340 T cgroup_freezing"
+	addr = "ffffffff91b2a340"
+	sym  = "cgroup_freezing"
+)
+
 func TestKsym(t *testing.T) {
-	data := "ffffffff91b2a340 T cgroup_freezing"
 
 	r := strings.NewReader(data)
-	fn := ksym("ffffffff91b2a340", r)
+	fn := kLookup(addr, r, ADDRCOL, SYMCOL)
 
-	if fn != "cgroup_freezing" {
+	if fn != sym {
+		t.Error("unexpected result")
+	}
+}
+
+func TestKaddr(t *testing.T) {
+
+	r := strings.NewReader(data)
+	fn := kLookup(sym, r, SYMCOL, ADDRCOL)
+
+	if fn != addr {
 		t.Error("unexpected result")
 	}
 }


### PR DESCRIPTION
This allows gobpf users to look up kernel addresses from function names.
A test is included to verify functionality, and some of the existing ksym code is reused, since the logic is nearly identical.

Additionally on my machine this code can successfully:
```
go build
gofmt     # no changes
go test
```

(First time contributor to this project, but I _think_ I followed the guidelines)