### PR TITLE
Feature/queuestack

### DIFF
--- a/bcc/queuestack.go
+++ b/bcc/queuestack.go
@@ -19,7 +19,11 @@ func IsQueueStack(table *Table) bool {
 }
 
 type QueueStack struct {
-	Table
+	*Table
+}
+
+func NewQueueStack(table *Table) *QueueStack {
+	return &QueueStack{Table: table}
 }
 
 func (queue *QueueStack) Push(leaf []byte, flags int) error {

--- a/bcc/queuestack.go
+++ b/bcc/queuestack.go
@@ -1,0 +1,100 @@
+package bcc
+
+/*
+#cgo CFLAGS: -I/usr/include/bcc/compat
+#cgo LDFLAGS: -lbcc
+#include <linux/bpf.h>
+#include <bcc/bcc_common.h>
+#include <bcc/libbpf.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+func IsQueueStack(table *Table) bool {
+	ttype := C.bpf_table_type_id(table.module, table.id)
+	return ttype == C.BPF_MAP_TYPE_QUEUE || ttype == C.BPF_MAP_TYPE_STACK
+}
+
+type QueueStack struct {
+	Table
+}
+
+func (queue *QueueStack) Push(leaf []byte, flags int) error {
+	fd := C.bpf_table_fd_id(queue.Table.module.p, queue.Table.id)
+
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_update_elem(fd, nil, leafP, flags)
+	if r != 0 {
+		leafStr, errL := queue.Table.LeafBytesToStr(leaf)
+		if errL != nil {
+			leafStr = fmt.Sprintf("%v", leaf)
+		}
+
+		return fmt.Errorf("QueueStack.Push: %v: %v", leafStr, err)
+	}
+	return nil
+}
+
+func (queue *QueueStack) Pop() ([]byte, error) {
+	fd := C.bpf_table_fd_id(queue.Table.module.p, queue.Table.id)
+
+	leafSize := C.bpf_table_leaf_size_id(queue.Table.module.p, queue.Table.id)
+
+	leaf := make([]byte, leafSize)
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_lookup_and_delete(fd, nil, leafP)
+	if r != 0 {
+		return nil, fmt.Errorf("QueueStack.Pop: %v", err)
+	}
+	return leaf, nil
+}
+
+func (queue *QueueStack) PopP() (unsafe.Pointer, error) {
+	fd := C.bpf_table_fd_id(queue.Table.module.p, queue.Table.id)
+
+	leafSize := C.bpf_table_leaf_size_id(queue.Table.module.p, queue.Table.id)
+
+	leaf := make([]byte, leafSize)
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_lookup_and_delete(fd, nil, leafP)
+	if r != 0 {
+		return nil, fmt.Errorf("QueueStack.PopP: %v", err)
+	}
+	return leafP, nil
+}
+
+func (queue *QueueStack) Peek() ([]byte, error) {
+	fd := C.bpf_table_fd_id(queue.Table.module.p, queue.Table.id)
+
+	leafSize := C.bpf_table_leaf_size_id(queue.Table.module.p, queue.Table.id)
+
+	leaf := make([]byte, leafSize)
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_lookup_elem(fd, nil, leafP)
+	if r != 0 {
+		return nil, fmt.Errorf("QueueStack.Peek: %v", err)
+	}
+	return leaf, nil
+}
+
+func (queue *QueueStack) PeekP() (unsafe.Pointer, error) {
+	fd := C.bpf_table_fd_id(queue.Table.module.p, queue.Table.id)
+
+	leafSize := C.bpf_table_leaf_size_id(queue.Table.module.p, queue.Table.id)
+
+	leaf := make([]byte, leafSize)
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_lookup_elem(fd, nil, leafP)
+	if r != 0 {
+		return nil, fmt.Errorf("QueueStack.Peek: %v", err)
+	}
+	return leafP, nil
+}

--- a/bcc/queuestack.go
+++ b/bcc/queuestack.go
@@ -14,7 +14,7 @@ import (
 )
 
 func IsQueueStack(table *Table) bool {
-	ttype := C.bpf_table_type_id(table.module, table.id)
+	ttype := C.bpf_table_type_id(table.module.p, table.id)
 	return ttype == C.BPF_MAP_TYPE_QUEUE || ttype == C.BPF_MAP_TYPE_STACK
 }
 
@@ -31,7 +31,7 @@ func (queue *QueueStack) Push(leaf []byte, flags int) error {
 
 	leafP := unsafe.Pointer(&leaf[0])
 
-	r, err := C.bpf_update_elem(fd, nil, leafP, flags)
+	r, err := C.bpf_update_elem(fd, nil, leafP, C.ulonglong(flags))
 	if r != 0 {
 		leafStr, errL := queue.Table.LeafBytesToStr(leaf)
 		if errL != nil {

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -270,6 +270,21 @@ func (table *Table) DeleteAll() error {
 	return nil
 }
 
+func (table *Table) Pop() ([]byte, error) {
+	fd := C.bpf_table_fd_id(table.module.p, table.id)
+
+	leafSize := C.bpf_table_leaf_size_id(table.module.p, table.id)
+	leaf := make([]byte, leafSize)
+	leafP := unsafe.Pointer(&leaf[0])
+
+	r, err := C.bpf_pop_elem(fd, leafP)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("r: %v\n", r)
+	return leaf, nil
+}
+
 // TableIterator contains the current position for iteration over a *bcc.Table and provides methods for iteration.
 type TableIterator struct {
 	table *Table

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -277,7 +277,7 @@ func (table *Table) Pop() ([]byte, error) {
 	leaf := make([]byte, leafSize)
 	leafP := unsafe.Pointer(&leaf[0])
 
-	r, err := C.bpf_pop_elem(fd, leafP)
+	r, err := C.bpf_map_pop_elem(fd, leafP)
 	if err != nil {
 		return nil, err
 	}

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -270,21 +270,6 @@ func (table *Table) DeleteAll() error {
 	return nil
 }
 
-func (table *Table) Pop() ([]byte, error) {
-	fd := C.bpf_table_fd_id(table.module.p, table.id)
-
-	leafSize := C.bpf_table_leaf_size_id(table.module.p, table.id)
-	leaf := make([]byte, leafSize)
-	leafP := unsafe.Pointer(&leaf[0])
-
-	r, err := C.bpf_map_pop_elem(fd, leafP)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Printf("r: %v\n", r)
-	return leaf, nil
-}
-
 // TableIterator contains the current position for iteration over a *bcc.Table and provides methods for iteration.
 type TableIterator struct {
 	table *Table


### PR DESCRIPTION
This implements QueueStack wrapper struct which implements Push, Peek and Pop methods for BPF_QUEUE and BPF_STACK.

They are implemented based on the Python implementation, but completely analogous to current Table implementations.

Table currently doesn't support Push, Pop and Peek methods which are queue and stack specific - I don't think they should be present in the Table struct because they aren't applicable to all types. Python library implements these as separate types that inherit the BaseTable type which is a good design decision imho.

I also included checking keySize in TableIterator Next method because it's possible to get panics out of Next method on empty maps.