### PR TITLE
Fix build on 32-bit arches

### DIFF
--- a/bcc/table.go
+++ b/bcc/table.go
@@ -151,7 +151,7 @@ func (table *Table) Get(key []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get possible cpus: %w", err)
 		}
-		leafSize *= C.ulong(len(cpus))
+		leafSize *= C.size_t(len(cpus))
 	}
 	leaf := make([]byte, leafSize)
 	leafP := unsafe.Pointer(&leaf[0])
@@ -180,7 +180,7 @@ func (table *Table) GetP(key unsafe.Pointer) (unsafe.Pointer, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get possible cpus: %w", err)
 		}
-		leafSize *= C.ulong(len(cpus))
+		leafSize *= C.size_t(len(cpus))
 	}
 	leaf := make([]byte, leafSize)
 	leafP := unsafe.Pointer(&leaf[0])
@@ -318,7 +318,7 @@ func (it *TableIterator) Next() bool {
 				it.err = fmt.Errorf("get possible cpus: %w", err)
 				return false
 			}
-			leafSize *= C.ulong(len(cpus))
+			leafSize *= C.size_t(len(cpus))
 		}
 		leaf := make([]byte, leafSize)
 


### PR DESCRIPTION
C.ulong isn't defined for 32-bit arches. Use C.size_t instead.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

oci-seccomp-bpf-hook vendors this repo and 32-bit builds are failing on fedora. See failure log for armv7hl:
https://koji.fedoraproject.org/koji/getfile?taskID=66857102&volume=DEFAULT&name=build.log&offset=-4000

/cc @vrothberg @ashcrow