### PR TITLE
elf: Add kprobe EventNameOption for unique eventName per Module

### DIFF
--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -68,6 +68,10 @@ func (b *Module) EnableTracepoint(secName string) error {
 	return errNotSupported
 }
 
+func (b *Module) TrySetKprobeEventNameOpts(evOpts EventNameOption) error {
+	return errNotSupported
+}
+
 func (b *Module) IterMaps() <-chan *Map {
 	return nil
 }


### PR DESCRIPTION
#251 : can't attach two functions for the same kprobe event
#271 : make uprobe eventname with symbol address (maybe similar issue)

### Intention

Currently, gobpf/elf Module make kprobe eventName like this:
https://github.com/iovisor/gobpf/blob/2289761f1e2092a7416cd5fd55a218802d997cb6/elf/module.go#L359
https://github.com/iovisor/gobpf/blob/2289761f1e2092a7416cd5fd55a218802d997cb6/elf/module.go#L746-L751

Such a naming works well when we use it temporarily.
However, this situation can happen: (Also I get stuck)
1. Program 1 attaches a probe at an address (such as kprobe/tcp_sendmsg)
2. Program 2 attaches a probe at the address
3. Even though eBPF allows multiple probes at the same address*, error occurred: "could not enable kprobe_events: file exists"

 _*The Kernel document says that we can actually attach two different probes at the same address.
https://www.kernel.org/doc/Documentation/kprobes.txt  : 5. Kprobes Features and Limitations_

I know that this issue is a little tricky to handle in the library. I tried to fix this issue in my use.
But It was much more tricky to handle unexported fields and methods... So I made this PR.

### Changed Files
* `elf/module.go` : Add a field `kprobeEvOpts EventNameOption` in `Module` therefore we can seperate a namespace of each Module.
* `elf/module_unsupported.go` : Adjust for unsupported module 

### Need to Fix
* Change gobpf/bcc.Module to work same as above.
* Move the body of `TrySetKprobeEventNameOpts()` to the constructor of `elf.Module` (?)
        - There are already 4 constructor in `elf.Module` such as... : `NewModuleWithLog`, `NewModuleFromReaderWithLog`, `NewModule`, `NewModuleFromReader`. Therefore I didn't make additional constructor.
