### PR TITLE
elf: Make build compatible with RHEL7

### DIFF
--- a/elf/include/uapi/linux/bpf.h
+++ b/elf/include/uapi/linux/bpf.h
@@ -837,14 +837,14 @@ union bpf_attr {
  *
  * 			int ret;
  * 			struct bpf_tunnel_key key = {};
- * 			
+ *
  * 			ret = bpf_skb_get_tunnel_key(skb, &key, sizeof(key), 0);
  * 			if (ret < 0)
  * 				return TC_ACT_SHOT;	// drop packet
- * 			
+ *
  * 			if (key.remote_ipv4 != 0x0a000001)
  * 				return TC_ACT_SHOT;	// drop packet
- * 			
+ *
  * 			return TC_ACT_OK;		// accept packet
  *
  * 		This interface can also be used with all encapsulation devices
@@ -3053,5 +3053,13 @@ struct bpf_line_info {
 	__u32	line_off;
 	__u32	line_col;
 };
+
+#ifndef SO_ATTACH_BPF
+#define SO_ATTACH_BPF 50
+#endif
+
+#ifndef SO_DETACH_BPF
+#define SO_DETACH_BPF SO_DETACH_FILTER
+#endif
 
 #endif /* _UAPI__LINUX_BPF_H__ */


### PR DESCRIPTION
Defining SO_ATTACH_BPF and SO_DETACH_BPF to fix go build and go install on RHEL7 OS.
For reference: Kernel version on RHEL7 is 3.10.x with eBPF capabilities
backported. (https://access.redhat.com/articles/3078 &
https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7)

But SO_ATTACH_BPF and SO_DETACH_BPF capabilities were added since kernel
version 3.19 onwards.

Without these changes, this is the error I get on my RHEL7 machine (with 3.10.0-1160 kernel) -
```bash
$ git branch -l
* master
  socket_compat
$ go build -a ./elf/
# github.com/iovisor/gobpf/elf
elf/module.go: In function 'bpf_attach_socket':
elf/module.go:96:38: error: 'SO_ATTACH_BPF' undeclared (first use in this function)
  return setsockopt(sock, SOL_SOCKET, SO_ATTACH_BPF, &fd, sizeof(fd));
                                      ^
elf/module.go:96:38: note: each undeclared identifier is reported only once for each function it appears in
elf/module.go: In function 'bpf_detach_socket':
elf/module.go:101:38: error: 'SO_DETACH_BPF' undeclared (first use in this function)
  return setsockopt(sock, SOL_SOCKET, SO_DETACH_BPF, &fd, sizeof(fd));
```