### PR TITLE
elf: Apply same kern_version.SUBLEVEL clamping as done by kernel

### DIFF
--- a/elf/kernel_version.go
+++ b/elf/kernel_version.go
@@ -49,6 +49,15 @@ func KernelVersionFromReleaseString(releaseString string) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// Apply same clamping as done by kernel when SUBLEVEL approaches 255
+	// See https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=a256aac5b7000
+	if major == 4 && minor == 14 && patch >= 252 {
+		patch = 255
+	} else if major == 4 && minor == 19 && patch >= 222 {
+		patch = 255
+	}
+
 	out := major*256*256 + minor*256 + patch
 	return uint32(out), nil
 }


### PR DESCRIPTION
ELF BPF module loading is failing on kernel 4.19.222 (and probably similar fails on 4.14.252) because of the clamping done on the kern_version SUBLEVEL value (clamped to 255 starting at 222). The library must do the same in order to avoid failing the kernel version check in the BPF syscall.