### PR TITLE
Bcc func load attachtype for bcc > 0.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           # Use release 9 of llvm etc. - later versions have an unfixed
           # bug on Ubuntu:
           # https://github.com/iovisor/bcc/issues/2915
-          sudo apt-get -y install bison build-essential cmake flex git libelf-dev libfl-dev libedit-dev libllvm9 llvm-9-dev libclang-9-dev python zlib1g-dev
+          sudo apt-get -y install bison build-essential cmake flex git libelf-dev libfl-dev libedit-dev libllvm11 llvm-11-dev libclang-cpp11-dev libclang-common-11-dev libclang1-11 libclang-11-dev python zlib1g-dev
           pushd /tmp
           git clone --depth 1 --branch v0.20.0 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
@@ -25,7 +25,7 @@ jobs:
           # The directory appears only to be created when installing the
           # virtual llvm-dev package.
           # https://github.com/iovisor/bcc/issues/492
-          sudo ln -s /usr/lib/llvm-9 /usr/local/llvm
+          sudo ln -s /usr/lib/llvm-11 /usr/local/llvm
           cmake ..
           make
           sudo make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           # https://github.com/iovisor/bcc/issues/2915
           sudo apt-get -y install bison build-essential cmake flex git libelf-dev libfl-dev libedit-dev libllvm11 llvm-11-dev libclang-cpp11-dev libclang-common-11-dev libclang1-11 libclang-11-dev python zlib1g-dev
           pushd /tmp
-          git clone --depth 1 --branch v0.20.0 https://github.com/iovisor/bcc.git
+          git clone --depth 1 --branch v0.25.0 https://github.com/iovisor/bcc.git
           mkdir -p bcc/build; cd bcc/build
           # Symlink /usr/lib/llvm to avoid "Unable to find clang libraries"
           # The directory appears only to be created when installing the


### PR DESCRIPTION
[bcc] Support for new `bcc_func_load` signature.

In https://github.com/iovisor/bcc/commit/ffff0edc00ad249cffbf44d855b15020cc968536
a new parameter was added to control the attach type. Subsequently, in https://github.com/iovisor/bcc/commit/815d1b84828c02ce10e1ea5163aede6b5786ba38,
`-1` was used to signal the default behaviour.

This change adds this new parameter to the call to `C.bcc_func_load`
when LIBBCC_VERSION is greater than 0.24.0, the last cut version which
did not introduce this change.
