### PR TITLE
fix parse tarceline

### DIFF
--- a/pkg/tracepipe/trace_pipe.go
+++ b/pkg/tracepipe/trace_pipe.go
@@ -65,7 +65,8 @@ func New() (*TracePipe, error) {
 
 // A line from trace_pipe looks like (leading spaces included):
 // `        chromium-15581 [000] d... 92783.722567: : Hello, World!`
-var traceLineRegexp = regexp.MustCompile(`(.{16})-(\d+) +\[(\d{3})\] (.{4}) +(\d+\.\d+)\: (.*?)\: (.*)`)
+// `        chromium-15581 [000] d...1 92783.722567: : Hello, World!`
+var traceLineRegexp = regexp.MustCompile(`(.{16})-(\d+) +\[(\d{3})\] (.{4,5}) +(\d+\.\d+)\: (.*?)\: (.*)`)
 
 func parseTraceLine(raw string) (*TraceEvent, error) {
 	fields := traceLineRegexp.FindStringSubmatch(raw)

--- a/pkg/tracepipe/trace_pipe_test.go
+++ b/pkg/tracepipe/trace_pipe_test.go
@@ -41,6 +41,14 @@ func TestParseTraceLine(t *testing.T) {
 				Message:  "hello: world",
 			},
 		},
+				{
+			"         systemd-1       [001] d...1 223345.525322: bpf_trace_printk: hello world!!!\n",
+			TraceEvent{
+				Task:     "systemd",
+				Function: "bpf_trace_printk",
+				Message:  "hello world!!!",
+			},
+		},
 	}
 	for _, testEvent := range testEvents {
 		result, err := parseTraceLine(testEvent.input)


### PR DESCRIPTION
fix tracepipe parseTraceLine bug, where tarceLine like this:
```
            bash-110023  [001] d...1 235601.276492: bpf_trace_printk: hello world!!!\n
```
my env:
```bash
[root@fedora ~]# uname -a
Linux fedora 5.17.5-300.fc36.aarch64 #1 SMP Thu Apr 28 15:22:08 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
[root@fedora ~]# cat /etc/fedora-release
Fedora release 36 (Thirty Six)
``` 