### PR TITLE
Add utsname support for loong64

### DIFF
--- a/elf/utsname_int8.go
+++ b/elf/utsname_int8.go
@@ -1,4 +1,4 @@
-// +build linux,386 linux,amd64 linux,arm64
+// +build linux,386 linux,amd64 linux,arm64 linux,loong64
 
 package elf
 


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

Utsname is modified according to file: https://go.dev/src/syscall/ztypes_linux_loong64.go
