### PR TITLE
elf: Add utsname support for riscv64

### DIFF
--- a/elf/utsname_uint8.go
+++ b/elf/utsname_uint8.go
@@ -1,4 +1,4 @@
-// +build linux,arm linux,ppc64 linux,ppc64le s390x
+// +build linux,arm linux,ppc64 linux,ppc64le linux,riscv64 s390x
 
 package elf
 


### PR DESCRIPTION
According to https://go.dev/src/syscall/ztypes_linux_riscv64.go#L573 we should use uint8 on riscv64.