### PR TITLE
fix(compile  warning): warning: non-void function does not return a v…

### DIFF
--- a/elf/table.go
+++ b/elf/table.go
@@ -53,7 +53,7 @@ static void create_bpf_lookup_elem(int fd, void *key, void *value, void *attr)
 	ptr_bpf_attr->value = ptr_to_u64(value);
 }
 
-static int next_bpf_elem(int fd, void *key, void *next_key, void *attr)
+static void next_bpf_elem(int fd, void *key, void *next_key, void *attr)
 {
 	union bpf_attr* ptr_bpf_attr;
 	ptr_bpf_attr = (union bpf_attr*)attr;


### PR DESCRIPTION
…alue

iovisor/gobpf/elf/table.go:63:1: warning: non-void function does not return a value [-Wreturn-type] This function(next_bpf_elem) doesn't need a return value for the call logic, so change the definition of the function to void