### PR TITLE
Defining SO_ATTACH_BPF and SO_DETACH_BPF to fix go build and go install on RHEL7 OS.

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -93,11 +93,13 @@ int bpf_prog_detach(int prog_fd, int target_fd, enum bpf_attach_type type)
 
 int bpf_attach_socket(int sock, int fd)
 {
+	const SO_ATTACH_BPF = 50;
 	return setsockopt(sock, SOL_SOCKET, SO_ATTACH_BPF, &fd, sizeof(fd));
 }
 
 int bpf_detach_socket(int sock, int fd)
 {
+	const SO_DETACH_BPF = 27;
 	return setsockopt(sock, SOL_SOCKET, SO_DETACH_BPF, &fd, sizeof(fd));
 }
 


### PR DESCRIPTION
Fix go build failure issue on RHEL7 OS. The error message shows as below:

$ go build -a ./elf/
github.com/iovisor/gobpf/elf
elf/module.go: In function 'bpf_attach_socket':
elf/module.go:96:38: error: 'SO_ATTACH_BPF' undeclared (first use in this function)
  return setsockopt(sock, SOL_SOCKET, SO_ATTACH_BPF, &fd, sizeof(fd));
                                      ^
elf/module.go:96:38: note: each undeclared identifier is reported only once for each function it appears in
elf/module.go: In function 'bpf_detach_socket':
elf/module.go:101:38: error: 'SO_DETACH_BPF' undeclared (first use in this function)
  return setsockopt(sock, SOL_SOCKET, SO_DETACH_BPF, &fd, sizeof(fd));
